### PR TITLE
building on Mac OS X 10.7

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -197,6 +197,10 @@ my $cleanup = qq{
                  lib/Math/GSL/[A-z]+/* blib *.so *.orig 
                  } . join " ", map { catfile( (qw( lib Math GSL ), "$_.pm") ) } @Subsystems;
 
+if ($^O ne 'darwin') {
+    $ldflags = '-shared ' . $ldflags;
+}
+
 my $builder = GSLBuilder->new( 
     module_name         => 'Math::GSL',
     add_to_cleanup      => [ $cleanup ],
@@ -205,7 +209,7 @@ my $builder = GSLBuilder->new(
     dist_author         => 'Jonathan Leto <jonathan@leto.net>',
     dist_version_from   => 'lib/Math/GSL.pm',
     include_dirs	    => [],
-    extra_linker_flags  => '-shared ' . $ldflags,
+    extra_linker_flags  => $ldflags,
     extra_compiler_flags=> "$ccflags " . ($ENV{CC_FLAGS}||''),
     swig_flags          => $swig_flags, 
     license             => 'gpl',


### PR DESCRIPTION
I tried to install this on Mac OS X 10.7 DP4 and got the following error:

tadam@tadam:~/src/Math-GSL-0.25_01$ perl Build.PL 
Checking for GSL..Found GSL version 1.14
Checking if llvm-gcc-4.2 supports "-Wall"...yes
Checking if llvm-gcc-4.2 supports "-Wno-unused-function"...yes
Checking if llvm-gcc-4.2 supports "-Wno-unused-value"...yes
Checking if llvm-gcc-4.2 supports "-Wno-unused-function"...yes
Checking if llvm-gcc-4.2 supports "-Wno-unused-variable"...yes
Checking if llvm-gcc-4.2 supports "-g"...yes
Created MYMETA.yml and MYMETA.json
Creating new 'Build' script for 'Math-GSL' version '0.25_01'
Have a great day!
tadam@tadam:~/src/Math-GSL-0.25_01$ ./Build 
Building Math-GSL
i686-apple-darwin11-llvm-gcc-4.2: -bundle not allowed with -dynamiclib
error building blib/arch/auto/Math/GSL/BLAS/BLAS.bundle file from 'xs/BLAS_wrap.o' at inc/GSLBuilder.pm line 132.
tadam@tadam:~/src/Math-GSL-0.25_01$ 

Exact do_system() call is:
tadam@tadam:~/src/Math-GSL-0.25_01$ gcc -o blib/arch/auto/Math/GSL/BLAS/BLAS.bundle xs/BLAS_wrap.o -shared -L/usr/local/Cellar/gsl/1.14/lib -lgsl -lgslcblas -lm -gsl -bundle -flat_namespace /System/Library/Perl/5.12/darwin-thread-multi-2level/CORE/libperl.dylib
i686-apple-darwin11-llvm-gcc-4.2: -bundle not allowed with -dynamiclib
tadam@tadam:~/src/Math-GSL-0.25_01$ 

The problem in this cmd is -shared option which treats as -dynamiclib (-dylib) option (but -shared and -dynamiclib not documented in 'man ld'). So I submit a patch.
