### PR TITLE
remove PkgConfig from runtime requires

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -137,7 +137,6 @@ my $builder = GSLBuilder->new(
         'Test::Taint'     => '1.06',
     },
     requires => {
-        'PkgConfig'       => '0.07720',
         'Scalar::Util'    => 0,
         'version'         => '0.77',
         'perl'            => '5.8.0',


### PR DESCRIPTION
I barely understand interactions that happen between dist, meta files and tools that use them so I might not know something, but PkgConfig should only be in 'configure_requires' and not in 'requires', as it is not a runtime dependency