### PR TITLE
Correct "it's"s to "its"s.

### DIFF
--- a/lib/Math/GSL.pm
+++ b/lib/Math/GSL.pm
@@ -59,7 +59,7 @@ Version 0.34
     # which will stringify to a version number
     my $gsl_version = gsl_version();
 
-Each GSL subsystem has it's own module. For example, the random number generator
+Each GSL subsystem has its own module. For example, the random number generator
 subsystem is Math::GSL::RNG. Many subsystems have a more Perlish and
 object-oriented frontend which can be used, as the above example shows. The raw
 GSL object is useful for using the low-level GSL functions, which in the case of

--- a/pod/Sort.pod
+++ b/pod/Sort.pod
@@ -142,7 +142,7 @@ documentation: L<http://www.gnu.org/software/gsl/manual/html_node/>
 =head1 PERFORMANCE
 
 In the source code of Math::GSL, the file "examples/benchmark/sort" compares
-the performance of gsl_sort() to Perl's builtin sort() function. It's first
+the performance of gsl_sort() to Perl's builtin sort() function. Its first
 argument is the number of iterations and the second is the size of the array
 of numbers to sort. For example, to see a benchmark of 1000 iterations for 
 arrays of size 50000 you would type

--- a/pod/Vector.pod
+++ b/pod/Vector.pod
@@ -216,7 +216,7 @@ sub norm($;$)
 
 =head2 normalize($p)
 
-Divide each element of a vector by it's norm, hence creating a unit vector.
+Divide each element of a vector by its norm, hence creating a unit vector.
 Returns the vector for chaining.  If you just want the value of the norm
 without changing the vector, use C<norm()>. The default value for C<$p> is 2,
 which gives the familiar Euclidean distance norm.


### PR DESCRIPTION
Hi! Thanks for Math::GSL. This commit corrects some typos.

I also grepped for "its"s that are supposed to be "it's" but could not find anything offending.

Also note that in my code review, I found quite a lot of trailing whitespace (see http://perl-begin.org/tutorials/bad-elements/#trailing-whitespace ) in the file. Is there an interest in removing it with a regression test? If so, should I use https://metacpan.org/pod/Test::TrailingSpace or https://metacpan.org/pod/Test::EOL ?

Best regards,

-- Shlomi Fish