### PR TITLE
workaround '.' no longer being in @INC in perl 2.56 and onwards

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -89,7 +89,7 @@ my $cleanup = qq{
 
 $ldflags = '-shared ' . $ldflags unless GSLBuilder::is_darwin();
 
-my $ver2func = do(catfile(qw/inc ver2func/));
+my $ver2func = do(rel2abs(catfile(qw/inc ver2func/)));
 
 my $swig_version;
 


### PR DESCRIPTION
Avoids

                do "inc/ver2func" failed, '.' is no longer in @INC;
                did you mean do "./inc/ver2func"?

error on perl 5.26 and onwards by fully qualifying path to ver2func.