### PR TITLE
Fix Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ cache:
   - ccache
   - apt
   - directories:
+    - /tmp/gsl-2.4
+    - /tmp/gsl-2.3
     - /tmp/gsl-2.2.1
     - /tmp/gsl-2.0
     - /tmp/gsl-2.1
@@ -29,6 +31,8 @@ env:
         - CCACHE_CPP2=1
         - CC="ccache clang"
     matrix:
+        - GSL=2.4
+        - GSL=2.3
         - GSL=2.2.1
         - GSL=2.1
         - GSL=2.0
@@ -50,7 +54,7 @@ before_install: ./_travis/before_install.sh
 # Add verbosity for debugging
 install:
     # this should always point to the version we build the CPAN dist with
-    - PATH=/tmp/gsl-2.2.1/bin:$PATH cpanm --installdeps --notest . &> /dev/null
+    - PATH=/tmp/gsl-4/bin:$PATH cpanm --installdeps --notest . &> /dev/null
 
 before_script:
     - ulimit -c unlimited -S       # enable core dumps

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ cache:
   - ccache
   - apt
   - directories:
+    - /tmp/src
     - /tmp/gsl-2.4
     - /tmp/gsl-2.3
     - /tmp/gsl-2.2.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,9 +69,7 @@ script:
     - cd Math-GSL*
     - perl Build.PL
     - ./Build
-    # - ./Build test verbose=1
-    # -j3 saves us 3 seconds but makes the output really annoying to read
-    - prove -rblvs t/
+    - ./Build test
 
 # NOTE: this only finds the first corefile generated
 after_failure:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,16 +20,19 @@ before_cache:
   - rm -f /tmp/gsl-*/config.log /tmp/gsl-*/libtool
 
 perl:
+    - "5.26"
     - "5.24"
     - "5.20-extras" # -Duseshrplib -Duseithreads
     - "5.16"
     - "5.10"
     - "5.8"
 
+# GSL_CURRENT should always point to the version we build the CPAN dist with
 env:
     global:
         - CCACHE_CPP2=1
         - CC="ccache clang"
+        - GSL_CURRENT=2.2.1
     matrix:
         - GSL=2.4
         - GSL=2.3
@@ -53,8 +56,7 @@ before_install: ./_travis/before_install.sh
 
 # Add verbosity for debugging
 install:
-    # this should always point to the version we build the CPAN dist with
-    - PATH=/tmp/gsl-4/bin:$PATH cpanm --installdeps --notest . &> /dev/null
+    - PATH=/tmp/gsl-${GSL_CURRENT}/bin:$PATH cpanm --installdeps --notest . &> /dev/null
 
 before_script:
     - ulimit -c unlimited -S       # enable core dumps

--- a/_travis/before_install.sh
+++ b/_travis/before_install.sh
@@ -1,7 +1,17 @@
 #!/bin/bash
 set -ev
 
-_get_gsl () {
+get_gsl () {
+
+    if [ "$1" = master ] ; then
+        get_gsl_master
+    else
+        get_gsl_version $1 &> /dev/null
+
+    fi
+}
+
+get_gsl_version () {
     # only download if necessary
     if [ ! -e "gsl-$1.tar.gz" ]; then
         wget -q ftp://ftp.gnu.org/gnu/gsl/gsl-$1.tar.gz
@@ -14,11 +24,8 @@ _get_gsl () {
     cd ..
 }
 
-get_gsl () {
-    _get_gsl $1 &> /dev/null
-}
 
-_get_master_gsl () {
+get_master_gsl () {
 
     rmdir "gsl-master" && echo "removed empty gsl-master directory"
 
@@ -41,28 +48,18 @@ _get_master_gsl () {
     cd ..
 }
 
-get_master_gsl () {
-    _get_master_gsl
-    #_get_master_gsl &> /dev/null
-}
 
 cpanm -n PkgConfig
 export ORIG_DIR=`pwd`
 echo ORIG_DIR=$ORIG_DIR
 cd /tmp
-get_gsl 1.15
-get_gsl 1.16
-get_gsl 2.0
-get_gsl 2.1
-get_gsl 2.2.1
-get_gsl 2.3
-get_gsl 2.4
-get_master_gsl
+get_gsl $GSL
+get_gsl $GSL_CURRENT
 
 ls -la /tmp/
-ls -la /tmp/gsl-2.2.1/bin
+ls -la /tmp/gsl-${GSL_CURRENT}/bin
 cd $TRAVIS_BUILD_DIR
-LD_LIBRARY_PATH=/tmp/gsl-${GSL_CURRENT}/lib:$LD_LIBRARY_PATH PATH=/tmp/gsl-4/bin:$PATH perl Build.PL && ./Build && ./Build dist # create a CPAN dist with latest supported GSL release
+LD_LIBRARY_PATH=/tmp/gsl-${GSL_CURRENT}/lib:$LD_LIBRARY_PATH PATH=/tmp/gsl-${GSL_CURRENT}/bin:$PATH perl Build.PL && ./Build && ./Build dist # create a CPAN dist with latest supported GSL release
 cp Math-GSL*.tar.gz /tmp
 ls -la /tmp/Math-GSL*.tar.gz # now we have a CPAN dist to test on each version of GSL
 cd $ORIG_DIR

--- a/_travis/before_install.sh
+++ b/_travis/before_install.sh
@@ -53,7 +53,7 @@ cpanm -n PkgConfig
 export ORIG_DIR=`pwd`
 echo ORIG_DIR=$ORIG_DIR
 cd /tmp
-ls -la /tmp/
+ls -la /tmp/src
 get_gsl $GSL
 get_gsl $GSL_CURRENT
 

--- a/_travis/before_install.sh
+++ b/_travis/before_install.sh
@@ -19,6 +19,9 @@ get_gsl () {
 }
 
 _get_master_gsl () {
+    
+    rmdir "gsl-master" && echo "removed empty gsl-master directory"
+
     if [ ! -d "gsl-master" ]; then
         git clone git://git.savannah.gnu.org/gsl.git gsl-master
         cd gsl-master
@@ -52,12 +55,14 @@ get_gsl 1.16
 get_gsl 2.0
 get_gsl 2.1
 get_gsl 2.2.1
+get_gsl 2.3
+get_gsl 2.4
 get_master_gsl
 
 ls -la /tmp/
-ls -la /tmp/gsl-2.2.1/bin
-cd /home/travis/build/leto/math--gsl
-LD_LIBRARY_PATH=/tmp/gsl-2.2.1/lib:$LD_LIBRARY_PATH PATH=/tmp/gsl-2.2.1/bin:$PATH perl Build.PL && ./Build && ./Build dist # create a CPAN dist with latest supported GSL release
+ls -la /tmp/gsl-2.4/bin
+cd $TRAVIS_BUILD_DIR
+LD_LIBRARY_PATH=/tmp/gsl-4/lib:$LD_LIBRARY_PATH PATH=/tmp/gsl-4/bin:$PATH perl Build.PL && ./Build && ./Build dist # create a CPAN dist with latest supported GSL release
 cp Math-GSL*.tar.gz /tmp
 ls -la /tmp/Math-GSL*.tar.gz # now we have a CPAN dist to test on each version of GSL
 cd $ORIG_DIR

--- a/_travis/before_install.sh
+++ b/_travis/before_install.sh
@@ -19,7 +19,7 @@ get_gsl () {
 }
 
 _get_master_gsl () {
-    
+
     rmdir "gsl-master" && echo "removed empty gsl-master directory"
 
     if [ ! -d "gsl-master" ]; then
@@ -60,10 +60,9 @@ get_gsl 2.4
 get_master_gsl
 
 ls -la /tmp/
-ls -la /tmp/gsl-2.4/bin
+ls -la /tmp/gsl-2.2.1/bin
 cd $TRAVIS_BUILD_DIR
-LD_LIBRARY_PATH=/tmp/gsl-4/lib:$LD_LIBRARY_PATH PATH=/tmp/gsl-4/bin:$PATH perl Build.PL && ./Build && ./Build dist # create a CPAN dist with latest supported GSL release
+LD_LIBRARY_PATH=/tmp/gsl-${GSL_CURRENT}/lib:$LD_LIBRARY_PATH PATH=/tmp/gsl-4/bin:$PATH perl Build.PL && ./Build && ./Build dist # create a CPAN dist with latest supported GSL release
 cp Math-GSL*.tar.gz /tmp
 ls -la /tmp/Math-GSL*.tar.gz # now we have a CPAN dist to test on each version of GSL
 cd $ORIG_DIR
-

--- a/_travis/before_install.sh
+++ b/_travis/before_install.sh
@@ -13,10 +13,10 @@ get_gsl () {
 
 get_gsl_version () {
     # only download if necessary
-    if [ ! -e "gsl-$1.tar.gz" ]; then
-        wget -q ftp://ftp.gnu.org/gnu/gsl/gsl-$1.tar.gz
+    if [ ! -e "src/gsl-$1.tar.gz" ]; then
+        ( cd src; wget -q ftp://ftp.gnu.org/gnu/gsl/gsl-$1.tar.gz )
     fi
-    tar zxpf gsl-$1.tar.gz
+    tar zxpf src/gsl-$1.tar.gz
     cd gsl-$1
     ./configure --prefix /tmp/gsl-$1
     make -j2

--- a/_travis/before_install.sh
+++ b/_travis/before_install.sh
@@ -53,6 +53,7 @@ cpanm -n PkgConfig
 export ORIG_DIR=`pwd`
 echo ORIG_DIR=$ORIG_DIR
 cd /tmp
+ls -la /tmp/
 get_gsl $GSL
 get_gsl $GSL_CURRENT
 


### PR DESCRIPTION
This fixes the travis.ci configuration so that it works.  I optimized a few things, made caching for the source work, cleaned up the code.

However, the biggest problem was that testing the final distribution was arguably broken.  For example, the travis runs with GSL 2.4 passed unexpectedly, as when I manually performed the tests locally, they failed due to missing symbols in the GSL library.  The difference is that the travis builds use `prove -rblvs t/`, which does not set` PERL_DL_NONLAZY=1`, so misses link errors.  Running `./Build test` catches those errors.  I've switched testing to `./Build test`.
