### PR TITLE
Patch to make GSL_VAR defined.

### DIFF
--- a/swig/Integration.i
+++ b/swig/Integration.i
@@ -4,9 +4,11 @@
 %include "renames.i"
 
 %{
+    #include "gsl/gsl_types.h"
     #include "gsl/gsl_integration.h"
     #include "gsl/gsl_math.h"
 %}
+%include "gsl/gsl_types.h"
 %include "gsl/gsl_integration.h"
 %include "gsl/gsl_math.h"
 %include "../pod/Integration.pod"


### PR DESCRIPTION
Added the include file gsl/gsl_types.h to swig/Intgration.i. This should
make GSL_VAR defined when swig processes gsl/gsl_integration.h.

Issue: is this backwards compatible? Did the file `gsl/gsl_types.h` exist in earlier versions of GSL?
