### PR TITLE
Yet another Travis fix.  For Real This Time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ cache:
     - /tmp/gsl-master
 
 before_cache:
-  - rm -f /tmp/gsl-*/config.log /tmp/gsl-*/libtool
+  - rm -f ${GSL_INST_DIR}/gsl-*/config.log ${GSL_INST_DIR}/gsl-*/libtool
 
 perl:
     - "5.26"
@@ -34,6 +34,9 @@ env:
         - CCACHE_CPP2=1
         - CC="ccache clang"
         - GSL_CURRENT=2.2.1
+        - GSL_INST_DIR=/tmp
+        - GSL_SRC_DIR=/tmp/src
+        - DIST_DIR=/tmp
     matrix:
         - GSL=2.4
         - GSL=2.3
@@ -57,16 +60,16 @@ before_install: ./_travis/before_install.sh
 
 # Add verbosity for debugging
 install:
-    - PATH=/tmp/gsl-${GSL_CURRENT}/bin:$PATH cpanm --installdeps --notest . &> /dev/null
+    - PATH=${GSL_INST_DIR}/gsl-${GSL_CURRENT}/bin:$PATH cpanm --installdeps --notest . &> /dev/null
 
 before_script:
     - ulimit -c unlimited -S       # enable core dumps
 
 script:
-    - export LD_LIBRARY_PATH=/tmp/gsl-$GSL/lib
-    - export PATH=/tmp/gsl-$GSL/bin:$PATH
+    - export LD_LIBRARY_PATH=${GSL_INST_DIR}/gsl-$GSL/lib
+    - export PATH=${GSL_INST_DIR}/gsl-$GSL/bin:$PATH
     - cd /tmp
-    - tar zxpf Math-GSL*
+    - tar zxpf ${DIST_DIR}/Math-GSL*
     - cd Math-GSL*
     - perl Build.PL
     - ./Build

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ before_install: ./_travis/before_install.sh
 
 # Add verbosity for debugging
 install:
-    - PATH=${GSL_INST_DIR}/gsl-${GSL_CURRENT}/bin:$PATH cpanm --installdeps --notest . &> /dev/null
+    - PKG_CONFIG_PATH=${GSL_INST_DIR}/gsl-$GSL/lib/pkgconfig PATH=${GSL_INST_DIR}/gsl-${GSL_CURRENT}/bin:$PATH cpanm --installdeps --notest . &> /dev/null
 
 before_script:
     - ulimit -c unlimited -S       # enable core dumps

--- a/_travis/before_install.sh
+++ b/_travis/before_install.sh
@@ -4,7 +4,6 @@ set -euv
 
 : ${GSL_INST_DIR:?environment variable not specified}
 : ${GSL_SRC_DIR:?environment variable not specified}
-: ${DIST_DIR:?environment variable not specified}
 : ${GSL:?environment variable not specified}
 : ${GSL_CURRENT:?environment variable not specified}
 
@@ -71,6 +70,8 @@ ls -la $GSL_INST_DIR
 ls -la ${GSL_INST_DIR}/gsl-${GSL_CURRENT}/bin
 
 if [ -n "$TRAVIS_BUILD_DIR" ] ; then
+
+    : ${DIST_DIR:?environment variable not specified}
 
     # perform in subshell to avoid polluting this shell
     (

--- a/_travis/before_install.sh
+++ b/_travis/before_install.sh
@@ -38,7 +38,7 @@ get_gsl_version () (
 )
 
 
-get_master_gsl () (
+get_gsl_master () (
 
     set -euv
     cd $GSL_SRC_DIR


### PR DESCRIPTION
This commit does three things (more or less).  In order of importance:

1. It fixes a Travis bug introduced by commit 5503c10, which added a dependency on `Alien::GSL`. `Alien::GSL` was failing installation during the Travis dependency installation phase, as it could not find GSL. It uses `pkg-config` to find GSL, but this only works if a) GSL is in a standard system path (in the Travis environment it wasn't); or b) the `PKG_CONFIG_PATH` environment variable is appropriately set (it wasn't).  This commit sets PKG_CONFIG_PATH.

1. Commit 4238f64 misspelled a function name in before_install.sh, which caused Travis builds of GSL-master to fail.

1. `before_install.sh` is useful for priming a developer's environment to test against various versions of GSL, so it was tweaked to be able to be used as a standalone script.

The "more or less" part is that `before_install.sh` was made more verbose, to ease debugging Travis errors.