### PR TITLE
Fixes some potential problems with .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 *~
 pm
-.gitignore
 *.core
 core
 Build
@@ -12,6 +11,7 @@ _build
 tmp*
 pod2htm*
 lib/Math/GSL/[A-z0-9]*\.pm
+!lib/Math/GSL/Test.pm
 Makefile
 *.data
 foo*


### PR DESCRIPTION
This commit fixes an issue I experienced when debugging the travis script. In order to debug the travis script, I cloned the repository, then deleted the `.git` folder in the root directory to start from a clean state. Then I did `git init` and `git add .`, and pushed on to my own debugging GitHub repository (with travis-ci enabled).

However, this did not work smoothly. The travis script failed mysteriously due to missing files and missing directories.

I traced this problem back to the `.gitignore` file in the root directory. It contained `.gitignore` itself (!), which caused the `xs/` folder to be missing (since it only contained a single file with the name `.gitignore`). The other issue, was this ignore rule: `lib/Math/GSL/[A-z0-9]*\.pm`. I guess it was meant to exclude files generated by `./Build`, but now it also excluded the existing content of `lib/Math/GSL`, namely the single file `lib/Math/GSL/Test.pm`. This caused the `lib/` folder to be missing. But, still the file `lib/Math/GSL/Test.pm` was included in the `MANIFEST` (and it was not
created by `./Build`) which meant that `./Build dist` would fail (due to the missing file).

I am not sure why `.gitignore` was ignored in the first place.  Even so, (by conincidence?) it did not produce any effect on the current repository.  I guess the reason must be that the rule was added in the git history later than the file `.gitignore` itself was added, meaning that the file `.gitignore` was still included, even though it was excluded from within `.gitignore`.

As far as I understand, the file `.gitignore` is supposed to be included in the repository, see https://stackoverflow.com/q/10176875/2173773
for more information, and excluding it does not make sense to me. Anybody knows why it was excluded?