### PR TITLE
Ignore generated rename files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ tags
 .DS_Store
 xs/*_wrap.c
 swig/renames.i
+swig/renames.*.i
 swig/system.i
 .prove
 Math-GSL-*/


### PR DESCRIPTION
The `./Build` script generates rename files on the form `swig/renames.1.15.i`, `swig/renames.1.16.i`, ..., `swig/renames.2.5.i` which are currently not ignored by `.gitignore`. In general, I feel that files generated by the build scripts should be ignored. For example in my use case, by ignoring these files I prevent them from showing up as untracked files in the git repository after running `./Build`. I usually use `git add .` as a simple shortcut to add stuff to be committed, and by ignoring these files I can continue using `git add .` and also avoid accidentally committing the generated rename files into a new commit.