### PR TITLE
Add version 2.6 to Ver2Func.pm

### DIFF
--- a/inc/Ver2Func.pm
+++ b/inc/Ver2Func.pm
@@ -293,10 +293,10 @@ my @ver2func = (
               /,
             [ '$ignore', '%$isvariable', '%$ismember', 'work_dbl' ],
             [ '$ignore', '%$isvariable', '%$ismember', 'work_sze' ],
-
-
         ],
     },
+    "2.6" => {
+    }
 );
 
 my ( %index, @info, @versions );


### PR DESCRIPTION
Adds a dummy entry 2.6 to the `@ver2func` array in `Ver2Func.pm`. This is enough to avoid _"Unsupported_ GSL version!!"_ error from `Build.PL`. We can in a later commit fill in more details in the `@ver2func` array, like the new and deprecated functions in 2.6.

This commit is the first commit in a series to solve #173 