### PR TITLE
Remove the `gsl_version.h` include from `SF.i`

### DIFF
--- a/swig/SF.i
+++ b/swig/SF.i
@@ -204,7 +204,6 @@ array_wrapper* gsl_sf_bessel_il_scaled_array_wrapper(int lmax, double x);
 %}
 
 %include "gsl/gsl_types.h"
-%include "gsl/gsl_version.h"
 %include "gsl/gsl_mode.h"
 %include "gsl/gsl_sf.h"
 %include "gsl/gsl_sf_airy.h"


### PR DESCRIPTION
This commit should have been included in commit b02b29c3, PR #179, *"Resolve conflict in GSL minor version definition"*, but since that is already merged I submit it as a separate pull request.