### PR TITLE
Update GSL_CURRENT to version 2.6 in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ env:
     global:
         - CCACHE_CPP2=1
         - CC="ccache clang"
-        - GSL_CURRENT=2.5
+        - GSL_CURRENT=2.6
         - GSL_INST_DIR=/tmp
         - GSL_SRC_DIR=/tmp/src
         - DIST_DIR=/tmp

--- a/MANIFEST
+++ b/MANIFEST
@@ -99,6 +99,7 @@ pm/Math/GSL/BLAS.pm.2.2.1
 pm/Math/GSL/BLAS.pm.2.3
 pm/Math/GSL/BLAS.pm.2.4
 pm/Math/GSL/BLAS.pm.2.5
+pm/Math/GSL/BLAS.pm.2.6
 pm/Math/GSL/BSpline.pm.1.15
 pm/Math/GSL/BSpline.pm.1.16
 pm/Math/GSL/BSpline.pm.2.0
@@ -108,6 +109,7 @@ pm/Math/GSL/BSpline.pm.2.2.1
 pm/Math/GSL/BSpline.pm.2.3
 pm/Math/GSL/BSpline.pm.2.4
 pm/Math/GSL/BSpline.pm.2.5
+pm/Math/GSL/BSpline.pm.2.6
 pm/Math/GSL/CBLAS.pm.1.15
 pm/Math/GSL/CBLAS.pm.1.16
 pm/Math/GSL/CBLAS.pm.2.0
@@ -117,6 +119,7 @@ pm/Math/GSL/CBLAS.pm.2.2.1
 pm/Math/GSL/CBLAS.pm.2.3
 pm/Math/GSL/CBLAS.pm.2.4
 pm/Math/GSL/CBLAS.pm.2.5
+pm/Math/GSL/CBLAS.pm.2.6
 pm/Math/GSL/CDF.pm.1.15
 pm/Math/GSL/CDF.pm.1.16
 pm/Math/GSL/CDF.pm.2.0
@@ -126,6 +129,7 @@ pm/Math/GSL/CDF.pm.2.2.1
 pm/Math/GSL/CDF.pm.2.3
 pm/Math/GSL/CDF.pm.2.4
 pm/Math/GSL/CDF.pm.2.5
+pm/Math/GSL/CDF.pm.2.6
 pm/Math/GSL/Chebyshev.pm.1.15
 pm/Math/GSL/Chebyshev.pm.1.16
 pm/Math/GSL/Chebyshev.pm.2.0
@@ -135,6 +139,7 @@ pm/Math/GSL/Chebyshev.pm.2.2.1
 pm/Math/GSL/Chebyshev.pm.2.3
 pm/Math/GSL/Chebyshev.pm.2.4
 pm/Math/GSL/Chebyshev.pm.2.5
+pm/Math/GSL/Chebyshev.pm.2.6
 pm/Math/GSL/Combination.pm.1.15
 pm/Math/GSL/Combination.pm.1.16
 pm/Math/GSL/Combination.pm.2.0
@@ -144,6 +149,7 @@ pm/Math/GSL/Combination.pm.2.2.1
 pm/Math/GSL/Combination.pm.2.3
 pm/Math/GSL/Combination.pm.2.4
 pm/Math/GSL/Combination.pm.2.5
+pm/Math/GSL/Combination.pm.2.6
 pm/Math/GSL/Complex.pm.1.15
 pm/Math/GSL/Complex.pm.1.16
 pm/Math/GSL/Complex.pm.2.0
@@ -153,6 +159,7 @@ pm/Math/GSL/Complex.pm.2.2.1
 pm/Math/GSL/Complex.pm.2.3
 pm/Math/GSL/Complex.pm.2.4
 pm/Math/GSL/Complex.pm.2.5
+pm/Math/GSL/Complex.pm.2.6
 pm/Math/GSL/Const.pm.1.15
 pm/Math/GSL/Const.pm.1.16
 pm/Math/GSL/Const.pm.2.0
@@ -162,6 +169,7 @@ pm/Math/GSL/Const.pm.2.2.1
 pm/Math/GSL/Const.pm.2.3
 pm/Math/GSL/Const.pm.2.4
 pm/Math/GSL/Const.pm.2.5
+pm/Math/GSL/Const.pm.2.6
 pm/Math/GSL/Deriv.pm.1.15
 pm/Math/GSL/Deriv.pm.1.16
 pm/Math/GSL/Deriv.pm.2.0
@@ -171,6 +179,7 @@ pm/Math/GSL/Deriv.pm.2.2.1
 pm/Math/GSL/Deriv.pm.2.3
 pm/Math/GSL/Deriv.pm.2.4
 pm/Math/GSL/Deriv.pm.2.5
+pm/Math/GSL/Deriv.pm.2.6
 pm/Math/GSL/DHT.pm.1.15
 pm/Math/GSL/DHT.pm.1.16
 pm/Math/GSL/DHT.pm.2.0
@@ -180,6 +189,7 @@ pm/Math/GSL/DHT.pm.2.2.1
 pm/Math/GSL/DHT.pm.2.3
 pm/Math/GSL/DHT.pm.2.4
 pm/Math/GSL/DHT.pm.2.5
+pm/Math/GSL/DHT.pm.2.6
 pm/Math/GSL/Diff.pm.1.15
 pm/Math/GSL/Diff.pm.1.16
 pm/Math/GSL/Diff.pm.2.0
@@ -189,6 +199,7 @@ pm/Math/GSL/Diff.pm.2.2.1
 pm/Math/GSL/Diff.pm.2.3
 pm/Math/GSL/Diff.pm.2.4
 pm/Math/GSL/Diff.pm.2.5
+pm/Math/GSL/Diff.pm.2.6
 pm/Math/GSL/Eigen.pm.1.15
 pm/Math/GSL/Eigen.pm.1.16
 pm/Math/GSL/Eigen.pm.2.0
@@ -198,6 +209,7 @@ pm/Math/GSL/Eigen.pm.2.2.1
 pm/Math/GSL/Eigen.pm.2.3
 pm/Math/GSL/Eigen.pm.2.4
 pm/Math/GSL/Eigen.pm.2.5
+pm/Math/GSL/Eigen.pm.2.6
 pm/Math/GSL/Errno.pm.1.15
 pm/Math/GSL/Errno.pm.1.16
 pm/Math/GSL/Errno.pm.2.0
@@ -207,6 +219,7 @@ pm/Math/GSL/Errno.pm.2.2.1
 pm/Math/GSL/Errno.pm.2.3
 pm/Math/GSL/Errno.pm.2.4
 pm/Math/GSL/Errno.pm.2.5
+pm/Math/GSL/Errno.pm.2.6
 pm/Math/GSL/FFT.pm.1.15
 pm/Math/GSL/FFT.pm.1.16
 pm/Math/GSL/FFT.pm.2.0
@@ -216,6 +229,7 @@ pm/Math/GSL/FFT.pm.2.2.1
 pm/Math/GSL/FFT.pm.2.3
 pm/Math/GSL/FFT.pm.2.4
 pm/Math/GSL/FFT.pm.2.5
+pm/Math/GSL/FFT.pm.2.6
 pm/Math/GSL/Fit.pm.1.15
 pm/Math/GSL/Fit.pm.1.16
 pm/Math/GSL/Fit.pm.2.0
@@ -225,6 +239,7 @@ pm/Math/GSL/Fit.pm.2.2.1
 pm/Math/GSL/Fit.pm.2.3
 pm/Math/GSL/Fit.pm.2.4
 pm/Math/GSL/Fit.pm.2.5
+pm/Math/GSL/Fit.pm.2.6
 pm/Math/GSL/Heapsort.pm.1.15
 pm/Math/GSL/Heapsort.pm.1.16
 pm/Math/GSL/Heapsort.pm.2.0
@@ -234,6 +249,7 @@ pm/Math/GSL/Heapsort.pm.2.2.1
 pm/Math/GSL/Heapsort.pm.2.3
 pm/Math/GSL/Heapsort.pm.2.4
 pm/Math/GSL/Heapsort.pm.2.5
+pm/Math/GSL/Heapsort.pm.2.6
 pm/Math/GSL/Histogram.pm.1.15
 pm/Math/GSL/Histogram.pm.1.16
 pm/Math/GSL/Histogram.pm.2.0
@@ -243,6 +259,7 @@ pm/Math/GSL/Histogram.pm.2.2.1
 pm/Math/GSL/Histogram.pm.2.3
 pm/Math/GSL/Histogram.pm.2.4
 pm/Math/GSL/Histogram.pm.2.5
+pm/Math/GSL/Histogram.pm.2.6
 pm/Math/GSL/Histogram2D.pm.1.15
 pm/Math/GSL/Histogram2D.pm.1.16
 pm/Math/GSL/Histogram2D.pm.2.0
@@ -252,6 +269,7 @@ pm/Math/GSL/Histogram2D.pm.2.2.1
 pm/Math/GSL/Histogram2D.pm.2.3
 pm/Math/GSL/Histogram2D.pm.2.4
 pm/Math/GSL/Histogram2D.pm.2.5
+pm/Math/GSL/Histogram2D.pm.2.6
 pm/Math/GSL/IEEEUtils.pm.1.15
 pm/Math/GSL/IEEEUtils.pm.1.16
 pm/Math/GSL/IEEEUtils.pm.2.0
@@ -261,6 +279,7 @@ pm/Math/GSL/IEEEUtils.pm.2.2.1
 pm/Math/GSL/IEEEUtils.pm.2.3
 pm/Math/GSL/IEEEUtils.pm.2.4
 pm/Math/GSL/IEEEUtils.pm.2.5
+pm/Math/GSL/IEEEUtils.pm.2.6
 pm/Math/GSL/Integration.pm.1.15
 pm/Math/GSL/Integration.pm.1.16
 pm/Math/GSL/Integration.pm.2.0
@@ -270,6 +289,7 @@ pm/Math/GSL/Integration.pm.2.2.1
 pm/Math/GSL/Integration.pm.2.3
 pm/Math/GSL/Integration.pm.2.4
 pm/Math/GSL/Integration.pm.2.5
+pm/Math/GSL/Integration.pm.2.6
 pm/Math/GSL/Interp.pm.1.15
 pm/Math/GSL/Interp.pm.1.16
 pm/Math/GSL/Interp.pm.2.0
@@ -279,6 +299,7 @@ pm/Math/GSL/Interp.pm.2.2.1
 pm/Math/GSL/Interp.pm.2.3
 pm/Math/GSL/Interp.pm.2.4
 pm/Math/GSL/Interp.pm.2.5
+pm/Math/GSL/Interp.pm.2.6
 pm/Math/GSL/Linalg.pm.1.15
 pm/Math/GSL/Linalg.pm.1.16
 pm/Math/GSL/Linalg.pm.2.0
@@ -288,6 +309,7 @@ pm/Math/GSL/Linalg.pm.2.2.1
 pm/Math/GSL/Linalg.pm.2.3
 pm/Math/GSL/Linalg.pm.2.4
 pm/Math/GSL/Linalg.pm.2.5
+pm/Math/GSL/Linalg.pm.2.6
 pm/Math/GSL/Machine.pm.1.15
 pm/Math/GSL/Machine.pm.1.16
 pm/Math/GSL/Machine.pm.2.0
@@ -297,6 +319,7 @@ pm/Math/GSL/Machine.pm.2.2.1
 pm/Math/GSL/Machine.pm.2.3
 pm/Math/GSL/Machine.pm.2.4
 pm/Math/GSL/Machine.pm.2.5
+pm/Math/GSL/Machine.pm.2.6
 pm/Math/GSL/Matrix.pm.1.15
 pm/Math/GSL/Matrix.pm.1.16
 pm/Math/GSL/Matrix.pm.2.0
@@ -306,6 +329,7 @@ pm/Math/GSL/Matrix.pm.2.2.1
 pm/Math/GSL/Matrix.pm.2.3
 pm/Math/GSL/Matrix.pm.2.4
 pm/Math/GSL/Matrix.pm.2.5
+pm/Math/GSL/Matrix.pm.2.6
 pm/Math/GSL/MatrixComplex.pm.1.15
 pm/Math/GSL/MatrixComplex.pm.1.16
 pm/Math/GSL/MatrixComplex.pm.2.0
@@ -315,6 +339,7 @@ pm/Math/GSL/MatrixComplex.pm.2.2.1
 pm/Math/GSL/MatrixComplex.pm.2.3
 pm/Math/GSL/MatrixComplex.pm.2.4
 pm/Math/GSL/MatrixComplex.pm.2.5
+pm/Math/GSL/MatrixComplex.pm.2.6
 pm/Math/GSL/Min.pm.1.15
 pm/Math/GSL/Min.pm.1.16
 pm/Math/GSL/Min.pm.2.0
@@ -324,6 +349,7 @@ pm/Math/GSL/Min.pm.2.2.1
 pm/Math/GSL/Min.pm.2.3
 pm/Math/GSL/Min.pm.2.4
 pm/Math/GSL/Min.pm.2.5
+pm/Math/GSL/Min.pm.2.6
 pm/Math/GSL/Monte.pm.1.15
 pm/Math/GSL/Monte.pm.1.16
 pm/Math/GSL/Monte.pm.2.0
@@ -333,18 +359,21 @@ pm/Math/GSL/Monte.pm.2.2.1
 pm/Math/GSL/Monte.pm.2.3
 pm/Math/GSL/Monte.pm.2.4
 pm/Math/GSL/Monte.pm.2.5
+pm/Math/GSL/Monte.pm.2.6
 pm/Math/GSL/Multifit.pm.2.1
 pm/Math/GSL/Multifit.pm.2.2
 pm/Math/GSL/Multifit.pm.2.2.1
 pm/Math/GSL/Multifit.pm.2.3
 pm/Math/GSL/Multifit.pm.2.4
 pm/Math/GSL/Multifit.pm.2.5
+pm/Math/GSL/Multifit.pm.2.6
 pm/Math/GSL/Multilarge.pm.2.1
 pm/Math/GSL/Multilarge.pm.2.2
 pm/Math/GSL/Multilarge.pm.2.2.1
 pm/Math/GSL/Multilarge.pm.2.3
 pm/Math/GSL/Multilarge.pm.2.4
 pm/Math/GSL/Multilarge.pm.2.5
+pm/Math/GSL/Multilarge.pm.2.6
 pm/Math/GSL/Multimin.pm.1.15
 pm/Math/GSL/Multimin.pm.1.16
 pm/Math/GSL/Multimin.pm.2.0
@@ -354,6 +383,7 @@ pm/Math/GSL/Multimin.pm.2.2.1
 pm/Math/GSL/Multimin.pm.2.3
 pm/Math/GSL/Multimin.pm.2.4
 pm/Math/GSL/Multimin.pm.2.5
+pm/Math/GSL/Multimin.pm.2.6
 pm/Math/GSL/Multiroots.pm.1.15
 pm/Math/GSL/Multiroots.pm.1.16
 pm/Math/GSL/Multiroots.pm.2.0
@@ -363,6 +393,7 @@ pm/Math/GSL/Multiroots.pm.2.2.1
 pm/Math/GSL/Multiroots.pm.2.3
 pm/Math/GSL/Multiroots.pm.2.4
 pm/Math/GSL/Multiroots.pm.2.5
+pm/Math/GSL/Multiroots.pm.2.6
 pm/Math/GSL/Multiset.pm.1.15
 pm/Math/GSL/Multiset.pm.1.16
 pm/Math/GSL/Multiset.pm.2.0
@@ -372,6 +403,7 @@ pm/Math/GSL/Multiset.pm.2.2.1
 pm/Math/GSL/Multiset.pm.2.3
 pm/Math/GSL/Multiset.pm.2.4
 pm/Math/GSL/Multiset.pm.2.5
+pm/Math/GSL/Multiset.pm.2.6
 pm/Math/GSL/NTuple.pm.1.15
 pm/Math/GSL/NTuple.pm.1.16
 pm/Math/GSL/NTuple.pm.2.0
@@ -381,6 +413,7 @@ pm/Math/GSL/NTuple.pm.2.2.1
 pm/Math/GSL/NTuple.pm.2.3
 pm/Math/GSL/NTuple.pm.2.4
 pm/Math/GSL/NTuple.pm.2.5
+pm/Math/GSL/NTuple.pm.2.6
 pm/Math/GSL/ODEIV.pm.1.15
 pm/Math/GSL/ODEIV.pm.1.16
 pm/Math/GSL/ODEIV.pm.2.0
@@ -390,6 +423,7 @@ pm/Math/GSL/ODEIV.pm.2.2.1
 pm/Math/GSL/ODEIV.pm.2.3
 pm/Math/GSL/ODEIV.pm.2.4
 pm/Math/GSL/ODEIV.pm.2.5
+pm/Math/GSL/ODEIV.pm.2.6
 pm/Math/GSL/Permutation.pm.1.15
 pm/Math/GSL/Permutation.pm.1.16
 pm/Math/GSL/Permutation.pm.2.0
@@ -399,6 +433,7 @@ pm/Math/GSL/Permutation.pm.2.2.1
 pm/Math/GSL/Permutation.pm.2.3
 pm/Math/GSL/Permutation.pm.2.4
 pm/Math/GSL/Permutation.pm.2.5
+pm/Math/GSL/Permutation.pm.2.6
 pm/Math/GSL/Poly.pm.1.15
 pm/Math/GSL/Poly.pm.1.16
 pm/Math/GSL/Poly.pm.2.0
@@ -408,6 +443,7 @@ pm/Math/GSL/Poly.pm.2.2.1
 pm/Math/GSL/Poly.pm.2.3
 pm/Math/GSL/Poly.pm.2.4
 pm/Math/GSL/Poly.pm.2.5
+pm/Math/GSL/Poly.pm.2.6
 pm/Math/GSL/PowInt.pm.1.15
 pm/Math/GSL/PowInt.pm.1.16
 pm/Math/GSL/PowInt.pm.2.0
@@ -417,6 +453,7 @@ pm/Math/GSL/PowInt.pm.2.2.1
 pm/Math/GSL/PowInt.pm.2.3
 pm/Math/GSL/PowInt.pm.2.4
 pm/Math/GSL/PowInt.pm.2.5
+pm/Math/GSL/PowInt.pm.2.6
 pm/Math/GSL/QRNG.pm.1.15
 pm/Math/GSL/QRNG.pm.1.16
 pm/Math/GSL/QRNG.pm.2.0
@@ -426,6 +463,7 @@ pm/Math/GSL/QRNG.pm.2.2.1
 pm/Math/GSL/QRNG.pm.2.3
 pm/Math/GSL/QRNG.pm.2.4
 pm/Math/GSL/QRNG.pm.2.5
+pm/Math/GSL/QRNG.pm.2.6
 pm/Math/GSL/Randist.pm.1.15
 pm/Math/GSL/Randist.pm.1.16
 pm/Math/GSL/Randist.pm.2.0
@@ -435,6 +473,7 @@ pm/Math/GSL/Randist.pm.2.2.1
 pm/Math/GSL/Randist.pm.2.3
 pm/Math/GSL/Randist.pm.2.4
 pm/Math/GSL/Randist.pm.2.5
+pm/Math/GSL/Randist.pm.2.6
 pm/Math/GSL/RNG.pm.1.15
 pm/Math/GSL/RNG.pm.1.16
 pm/Math/GSL/RNG.pm.2.0
@@ -444,6 +483,7 @@ pm/Math/GSL/RNG.pm.2.2.1
 pm/Math/GSL/RNG.pm.2.3
 pm/Math/GSL/RNG.pm.2.4
 pm/Math/GSL/RNG.pm.2.5
+pm/Math/GSL/RNG.pm.2.6
 pm/Math/GSL/Roots.pm.1.15
 pm/Math/GSL/Roots.pm.1.16
 pm/Math/GSL/Roots.pm.2.0
@@ -453,6 +493,7 @@ pm/Math/GSL/Roots.pm.2.2.1
 pm/Math/GSL/Roots.pm.2.3
 pm/Math/GSL/Roots.pm.2.4
 pm/Math/GSL/Roots.pm.2.5
+pm/Math/GSL/Roots.pm.2.6
 pm/Math/GSL/Rstat.pm.2.0
 pm/Math/GSL/Rstat.pm.2.1
 pm/Math/GSL/Rstat.pm.2.2
@@ -460,6 +501,7 @@ pm/Math/GSL/Rstat.pm.2.2.1
 pm/Math/GSL/Rstat.pm.2.3
 pm/Math/GSL/Rstat.pm.2.4
 pm/Math/GSL/Rstat.pm.2.5
+pm/Math/GSL/Rstat.pm.2.6
 pm/Math/GSL/SF.pm.1.15
 pm/Math/GSL/SF.pm.1.16
 pm/Math/GSL/SF.pm.2.0
@@ -469,6 +511,7 @@ pm/Math/GSL/SF.pm.2.2.1
 pm/Math/GSL/SF.pm.2.3
 pm/Math/GSL/SF.pm.2.4
 pm/Math/GSL/SF.pm.2.5
+pm/Math/GSL/SF.pm.2.6
 pm/Math/GSL/Siman.pm.1.15
 pm/Math/GSL/Siman.pm.1.16
 pm/Math/GSL/Siman.pm.2.0
@@ -478,6 +521,7 @@ pm/Math/GSL/Siman.pm.2.2.1
 pm/Math/GSL/Siman.pm.2.3
 pm/Math/GSL/Siman.pm.2.4
 pm/Math/GSL/Siman.pm.2.5
+pm/Math/GSL/Siman.pm.2.6
 pm/Math/GSL/Sort.pm.1.15
 pm/Math/GSL/Sort.pm.1.16
 pm/Math/GSL/Sort.pm.2.0
@@ -487,6 +531,7 @@ pm/Math/GSL/Sort.pm.2.2.1
 pm/Math/GSL/Sort.pm.2.3
 pm/Math/GSL/Sort.pm.2.4
 pm/Math/GSL/Sort.pm.2.5
+pm/Math/GSL/Sort.pm.2.6
 pm/Math/GSL/SparseMatrix.pm.2.0
 pm/Math/GSL/SparseMatrix.pm.2.1
 pm/Math/GSL/SparseMatrix.pm.2.2
@@ -494,6 +539,7 @@ pm/Math/GSL/SparseMatrix.pm.2.2.1
 pm/Math/GSL/SparseMatrix.pm.2.3
 pm/Math/GSL/SparseMatrix.pm.2.4
 pm/Math/GSL/SparseMatrix.pm.2.5
+pm/Math/GSL/SparseMatrix.pm.2.6
 pm/Math/GSL/Spline.pm.1.15
 pm/Math/GSL/Spline.pm.1.16
 pm/Math/GSL/Spline.pm.2.0
@@ -503,6 +549,7 @@ pm/Math/GSL/Spline.pm.2.2.1
 pm/Math/GSL/Spline.pm.2.3
 pm/Math/GSL/Spline.pm.2.4
 pm/Math/GSL/Spline.pm.2.5
+pm/Math/GSL/Spline.pm.2.6
 pm/Math/GSL/Statistics.pm.1.15
 pm/Math/GSL/Statistics.pm.1.16
 pm/Math/GSL/Statistics.pm.2.0
@@ -512,6 +559,7 @@ pm/Math/GSL/Statistics.pm.2.2.1
 pm/Math/GSL/Statistics.pm.2.3
 pm/Math/GSL/Statistics.pm.2.4
 pm/Math/GSL/Statistics.pm.2.5
+pm/Math/GSL/Statistics.pm.2.6
 pm/Math/GSL/Sum.pm.1.15
 pm/Math/GSL/Sum.pm.1.16
 pm/Math/GSL/Sum.pm.2.0
@@ -521,6 +569,7 @@ pm/Math/GSL/Sum.pm.2.2.1
 pm/Math/GSL/Sum.pm.2.3
 pm/Math/GSL/Sum.pm.2.4
 pm/Math/GSL/Sum.pm.2.5
+pm/Math/GSL/Sum.pm.2.6
 pm/Math/GSL/Sys.pm.1.15
 pm/Math/GSL/Sys.pm.1.16
 pm/Math/GSL/Sys.pm.2.0
@@ -530,6 +579,7 @@ pm/Math/GSL/Sys.pm.2.2.1
 pm/Math/GSL/Sys.pm.2.3
 pm/Math/GSL/Sys.pm.2.4
 pm/Math/GSL/Sys.pm.2.5
+pm/Math/GSL/Sys.pm.2.6
 pm/Math/GSL/Vector.pm.1.15
 pm/Math/GSL/Vector.pm.1.16
 pm/Math/GSL/Vector.pm.2.0
@@ -539,6 +589,7 @@ pm/Math/GSL/Vector.pm.2.2.1
 pm/Math/GSL/Vector.pm.2.3
 pm/Math/GSL/Vector.pm.2.4
 pm/Math/GSL/Vector.pm.2.5
+pm/Math/GSL/Vector.pm.2.6
 pm/Math/GSL/VectorComplex.pm.1.15
 pm/Math/GSL/VectorComplex.pm.1.16
 pm/Math/GSL/VectorComplex.pm.2.0
@@ -548,6 +599,7 @@ pm/Math/GSL/VectorComplex.pm.2.2.1
 pm/Math/GSL/VectorComplex.pm.2.3
 pm/Math/GSL/VectorComplex.pm.2.4
 pm/Math/GSL/VectorComplex.pm.2.5
+pm/Math/GSL/VectorComplex.pm.2.6
 pm/Math/GSL/Version.pm.1.15
 pm/Math/GSL/Version.pm.1.16
 pm/Math/GSL/Version.pm.2.0
@@ -557,6 +609,7 @@ pm/Math/GSL/Version.pm.2.2.1
 pm/Math/GSL/Version.pm.2.3
 pm/Math/GSL/Version.pm.2.4
 pm/Math/GSL/Version.pm.2.5
+pm/Math/GSL/Version.pm.2.6
 pm/Math/GSL/Wavelet.pm.1.15
 pm/Math/GSL/Wavelet.pm.1.16
 pm/Math/GSL/Wavelet.pm.2.0
@@ -566,6 +619,7 @@ pm/Math/GSL/Wavelet.pm.2.2.1
 pm/Math/GSL/Wavelet.pm.2.3
 pm/Math/GSL/Wavelet.pm.2.4
 pm/Math/GSL/Wavelet.pm.2.5
+pm/Math/GSL/Wavelet.pm.2.6
 pm/Math/GSL/Wavelet2D.pm.1.15
 pm/Math/GSL/Wavelet2D.pm.1.16
 pm/Math/GSL/Wavelet2D.pm.2.0
@@ -575,6 +629,7 @@ pm/Math/GSL/Wavelet2D.pm.2.2.1
 pm/Math/GSL/Wavelet2D.pm.2.3
 pm/Math/GSL/Wavelet2D.pm.2.4
 pm/Math/GSL/Wavelet2D.pm.2.5
+pm/Math/GSL/Wavelet2D.pm.2.6
 pod/BLAS.pod
 pod/BSpline.pod
 pod/CBLAS.pod
@@ -755,6 +810,7 @@ xs/BLAS_wrap.2.2.c
 xs/BLAS_wrap.2.3.c
 xs/BLAS_wrap.2.4.c
 xs/BLAS_wrap.2.5.c
+xs/BLAS_wrap.2.6.c
 xs/BSpline_wrap.1.15.c
 xs/BSpline_wrap.1.16.c
 xs/BSpline_wrap.2.0.c
@@ -764,6 +820,7 @@ xs/BSpline_wrap.2.2.c
 xs/BSpline_wrap.2.3.c
 xs/BSpline_wrap.2.4.c
 xs/BSpline_wrap.2.5.c
+xs/BSpline_wrap.2.6.c
 xs/CBLAS_wrap.1.15.c
 xs/CBLAS_wrap.1.16.c
 xs/CBLAS_wrap.2.0.c
@@ -773,6 +830,7 @@ xs/CBLAS_wrap.2.2.c
 xs/CBLAS_wrap.2.3.c
 xs/CBLAS_wrap.2.4.c
 xs/CBLAS_wrap.2.5.c
+xs/CBLAS_wrap.2.6.c
 xs/CDF_wrap.1.15.c
 xs/CDF_wrap.1.16.c
 xs/CDF_wrap.2.0.c
@@ -782,6 +840,7 @@ xs/CDF_wrap.2.2.c
 xs/CDF_wrap.2.3.c
 xs/CDF_wrap.2.4.c
 xs/CDF_wrap.2.5.c
+xs/CDF_wrap.2.6.c
 xs/Chebyshev_wrap.1.15.c
 xs/Chebyshev_wrap.1.16.c
 xs/Chebyshev_wrap.2.0.c
@@ -791,6 +850,7 @@ xs/Chebyshev_wrap.2.2.c
 xs/Chebyshev_wrap.2.3.c
 xs/Chebyshev_wrap.2.4.c
 xs/Chebyshev_wrap.2.5.c
+xs/Chebyshev_wrap.2.6.c
 xs/Combination_wrap.1.15.c
 xs/Combination_wrap.1.16.c
 xs/Combination_wrap.2.0.c
@@ -800,6 +860,7 @@ xs/Combination_wrap.2.2.c
 xs/Combination_wrap.2.3.c
 xs/Combination_wrap.2.4.c
 xs/Combination_wrap.2.5.c
+xs/Combination_wrap.2.6.c
 xs/Complex_wrap.1.15.c
 xs/Complex_wrap.1.16.c
 xs/Complex_wrap.2.0.c
@@ -809,6 +870,7 @@ xs/Complex_wrap.2.2.c
 xs/Complex_wrap.2.3.c
 xs/Complex_wrap.2.4.c
 xs/Complex_wrap.2.5.c
+xs/Complex_wrap.2.6.c
 xs/Const_wrap.1.15.c
 xs/Const_wrap.1.16.c
 xs/Const_wrap.2.0.c
@@ -818,6 +880,7 @@ xs/Const_wrap.2.2.c
 xs/Const_wrap.2.3.c
 xs/Const_wrap.2.4.c
 xs/Const_wrap.2.5.c
+xs/Const_wrap.2.6.c
 xs/Deriv_wrap.1.15.c
 xs/Deriv_wrap.1.16.c
 xs/Deriv_wrap.2.0.c
@@ -827,6 +890,7 @@ xs/Deriv_wrap.2.2.c
 xs/Deriv_wrap.2.3.c
 xs/Deriv_wrap.2.4.c
 xs/Deriv_wrap.2.5.c
+xs/Deriv_wrap.2.6.c
 xs/DHT_wrap.1.15.c
 xs/DHT_wrap.1.16.c
 xs/DHT_wrap.2.0.c
@@ -836,6 +900,7 @@ xs/DHT_wrap.2.2.c
 xs/DHT_wrap.2.3.c
 xs/DHT_wrap.2.4.c
 xs/DHT_wrap.2.5.c
+xs/DHT_wrap.2.6.c
 xs/Diff_wrap.1.15.c
 xs/Diff_wrap.1.16.c
 xs/Diff_wrap.2.0.c
@@ -845,6 +910,7 @@ xs/Diff_wrap.2.2.c
 xs/Diff_wrap.2.3.c
 xs/Diff_wrap.2.4.c
 xs/Diff_wrap.2.5.c
+xs/Diff_wrap.2.6.c
 xs/Eigen_wrap.1.15.c
 xs/Eigen_wrap.1.16.c
 xs/Eigen_wrap.2.0.c
@@ -854,6 +920,7 @@ xs/Eigen_wrap.2.2.c
 xs/Eigen_wrap.2.3.c
 xs/Eigen_wrap.2.4.c
 xs/Eigen_wrap.2.5.c
+xs/Eigen_wrap.2.6.c
 xs/Errno_wrap.1.15.c
 xs/Errno_wrap.1.16.c
 xs/Errno_wrap.2.0.c
@@ -863,6 +930,7 @@ xs/Errno_wrap.2.2.c
 xs/Errno_wrap.2.3.c
 xs/Errno_wrap.2.4.c
 xs/Errno_wrap.2.5.c
+xs/Errno_wrap.2.6.c
 xs/FFT_wrap.1.15.c
 xs/FFT_wrap.1.16.c
 xs/FFT_wrap.2.0.c
@@ -872,6 +940,7 @@ xs/FFT_wrap.2.2.c
 xs/FFT_wrap.2.3.c
 xs/FFT_wrap.2.4.c
 xs/FFT_wrap.2.5.c
+xs/FFT_wrap.2.6.c
 xs/Fit_wrap.1.15.c
 xs/Fit_wrap.1.16.c
 xs/Fit_wrap.2.0.c
@@ -881,6 +950,7 @@ xs/Fit_wrap.2.2.c
 xs/Fit_wrap.2.3.c
 xs/Fit_wrap.2.4.c
 xs/Fit_wrap.2.5.c
+xs/Fit_wrap.2.6.c
 xs/Heapsort_wrap.1.15.c
 xs/Heapsort_wrap.1.16.c
 xs/Heapsort_wrap.2.0.c
@@ -890,6 +960,7 @@ xs/Heapsort_wrap.2.2.c
 xs/Heapsort_wrap.2.3.c
 xs/Heapsort_wrap.2.4.c
 xs/Heapsort_wrap.2.5.c
+xs/Heapsort_wrap.2.6.c
 xs/Histogram2D_wrap.1.15.c
 xs/Histogram2D_wrap.1.16.c
 xs/Histogram2D_wrap.2.0.c
@@ -899,6 +970,7 @@ xs/Histogram2D_wrap.2.2.c
 xs/Histogram2D_wrap.2.3.c
 xs/Histogram2D_wrap.2.4.c
 xs/Histogram2D_wrap.2.5.c
+xs/Histogram2D_wrap.2.6.c
 xs/Histogram_wrap.1.15.c
 xs/Histogram_wrap.1.16.c
 xs/Histogram_wrap.2.0.c
@@ -908,6 +980,7 @@ xs/Histogram_wrap.2.2.c
 xs/Histogram_wrap.2.3.c
 xs/Histogram_wrap.2.4.c
 xs/Histogram_wrap.2.5.c
+xs/Histogram_wrap.2.6.c
 xs/IEEEUtils_wrap.1.15.c
 xs/IEEEUtils_wrap.1.16.c
 xs/IEEEUtils_wrap.2.0.c
@@ -917,6 +990,7 @@ xs/IEEEUtils_wrap.2.2.c
 xs/IEEEUtils_wrap.2.3.c
 xs/IEEEUtils_wrap.2.4.c
 xs/IEEEUtils_wrap.2.5.c
+xs/IEEEUtils_wrap.2.6.c
 xs/Integration_wrap.1.15.c
 xs/Integration_wrap.1.16.c
 xs/Integration_wrap.2.0.c
@@ -926,6 +1000,7 @@ xs/Integration_wrap.2.2.c
 xs/Integration_wrap.2.3.c
 xs/Integration_wrap.2.4.c
 xs/Integration_wrap.2.5.c
+xs/Integration_wrap.2.6.c
 xs/Interp_wrap.1.15.c
 xs/Interp_wrap.1.16.c
 xs/Interp_wrap.2.0.c
@@ -935,6 +1010,7 @@ xs/Interp_wrap.2.2.c
 xs/Interp_wrap.2.3.c
 xs/Interp_wrap.2.4.c
 xs/Interp_wrap.2.5.c
+xs/Interp_wrap.2.6.c
 xs/Linalg_wrap.1.15.c
 xs/Linalg_wrap.1.16.c
 xs/Linalg_wrap.2.0.c
@@ -944,6 +1020,7 @@ xs/Linalg_wrap.2.2.c
 xs/Linalg_wrap.2.3.c
 xs/Linalg_wrap.2.4.c
 xs/Linalg_wrap.2.5.c
+xs/Linalg_wrap.2.6.c
 xs/Machine_wrap.1.15.c
 xs/Machine_wrap.1.16.c
 xs/Machine_wrap.2.0.c
@@ -953,6 +1030,7 @@ xs/Machine_wrap.2.2.c
 xs/Machine_wrap.2.3.c
 xs/Machine_wrap.2.4.c
 xs/Machine_wrap.2.5.c
+xs/Machine_wrap.2.6.c
 xs/Matrix_wrap.1.15.c
 xs/Matrix_wrap.1.16.c
 xs/Matrix_wrap.2.0.c
@@ -962,6 +1040,7 @@ xs/Matrix_wrap.2.2.c
 xs/Matrix_wrap.2.3.c
 xs/Matrix_wrap.2.4.c
 xs/Matrix_wrap.2.5.c
+xs/Matrix_wrap.2.6.c
 xs/MatrixComplex_wrap.1.15.c
 xs/MatrixComplex_wrap.1.16.c
 xs/MatrixComplex_wrap.2.0.c
@@ -971,6 +1050,7 @@ xs/MatrixComplex_wrap.2.2.c
 xs/MatrixComplex_wrap.2.3.c
 xs/MatrixComplex_wrap.2.4.c
 xs/MatrixComplex_wrap.2.5.c
+xs/MatrixComplex_wrap.2.6.c
 xs/Min_wrap.1.15.c
 xs/Min_wrap.1.16.c
 xs/Min_wrap.2.0.c
@@ -980,6 +1060,7 @@ xs/Min_wrap.2.2.c
 xs/Min_wrap.2.3.c
 xs/Min_wrap.2.4.c
 xs/Min_wrap.2.5.c
+xs/Min_wrap.2.6.c
 xs/Monte_wrap.1.15.c
 xs/Monte_wrap.1.16.c
 xs/Monte_wrap.2.0.c
@@ -989,18 +1070,21 @@ xs/Monte_wrap.2.2.c
 xs/Monte_wrap.2.3.c
 xs/Monte_wrap.2.4.c
 xs/Monte_wrap.2.5.c
+xs/Monte_wrap.2.6.c
 xs/Multifit_wrap.2.1.c
 xs/Multifit_wrap.2.2.1.c
 xs/Multifit_wrap.2.2.c
 xs/Multifit_wrap.2.3.c
 xs/Multifit_wrap.2.4.c
 xs/Multifit_wrap.2.5.c
+xs/Multifit_wrap.2.6.c
 xs/Multilarge_wrap.2.1.c
 xs/Multilarge_wrap.2.2.1.c
 xs/Multilarge_wrap.2.2.c
 xs/Multilarge_wrap.2.3.c
 xs/Multilarge_wrap.2.4.c
 xs/Multilarge_wrap.2.5.c
+xs/Multilarge_wrap.2.6.c
 xs/Multimin_wrap.1.15.c
 xs/Multimin_wrap.1.16.c
 xs/Multimin_wrap.2.0.c
@@ -1010,6 +1094,7 @@ xs/Multimin_wrap.2.2.c
 xs/Multimin_wrap.2.3.c
 xs/Multimin_wrap.2.4.c
 xs/Multimin_wrap.2.5.c
+xs/Multimin_wrap.2.6.c
 xs/Multiroots_wrap.1.15.c
 xs/Multiroots_wrap.1.16.c
 xs/Multiroots_wrap.2.0.c
@@ -1019,6 +1104,7 @@ xs/Multiroots_wrap.2.2.c
 xs/Multiroots_wrap.2.3.c
 xs/Multiroots_wrap.2.4.c
 xs/Multiroots_wrap.2.5.c
+xs/Multiroots_wrap.2.6.c
 xs/Multiset_wrap.1.15.c
 xs/Multiset_wrap.1.16.c
 xs/Multiset_wrap.2.0.c
@@ -1028,6 +1114,7 @@ xs/Multiset_wrap.2.2.c
 xs/Multiset_wrap.2.3.c
 xs/Multiset_wrap.2.4.c
 xs/Multiset_wrap.2.5.c
+xs/Multiset_wrap.2.6.c
 xs/NTuple_wrap.1.15.c
 xs/NTuple_wrap.1.16.c
 xs/NTuple_wrap.2.0.c
@@ -1037,6 +1124,7 @@ xs/NTuple_wrap.2.2.c
 xs/NTuple_wrap.2.3.c
 xs/NTuple_wrap.2.4.c
 xs/NTuple_wrap.2.5.c
+xs/NTuple_wrap.2.6.c
 xs/ODEIV_wrap.1.15.c
 xs/ODEIV_wrap.1.16.c
 xs/ODEIV_wrap.2.0.c
@@ -1046,6 +1134,7 @@ xs/ODEIV_wrap.2.2.c
 xs/ODEIV_wrap.2.3.c
 xs/ODEIV_wrap.2.4.c
 xs/ODEIV_wrap.2.5.c
+xs/ODEIV_wrap.2.6.c
 xs/Permutation_wrap.1.15.c
 xs/Permutation_wrap.1.16.c
 xs/Permutation_wrap.2.0.c
@@ -1055,6 +1144,7 @@ xs/Permutation_wrap.2.2.c
 xs/Permutation_wrap.2.3.c
 xs/Permutation_wrap.2.4.c
 xs/Permutation_wrap.2.5.c
+xs/Permutation_wrap.2.6.c
 xs/Poly_wrap.1.15.c
 xs/Poly_wrap.1.16.c
 xs/Poly_wrap.2.0.c
@@ -1064,6 +1154,7 @@ xs/Poly_wrap.2.2.c
 xs/Poly_wrap.2.3.c
 xs/Poly_wrap.2.4.c
 xs/Poly_wrap.2.5.c
+xs/Poly_wrap.2.6.c
 xs/PowInt_wrap.1.15.c
 xs/PowInt_wrap.1.16.c
 xs/PowInt_wrap.2.0.c
@@ -1073,6 +1164,7 @@ xs/PowInt_wrap.2.2.c
 xs/PowInt_wrap.2.3.c
 xs/PowInt_wrap.2.4.c
 xs/PowInt_wrap.2.5.c
+xs/PowInt_wrap.2.6.c
 xs/QRNG_wrap.1.15.c
 xs/QRNG_wrap.1.16.c
 xs/QRNG_wrap.2.0.c
@@ -1082,6 +1174,7 @@ xs/QRNG_wrap.2.2.c
 xs/QRNG_wrap.2.3.c
 xs/QRNG_wrap.2.4.c
 xs/QRNG_wrap.2.5.c
+xs/QRNG_wrap.2.6.c
 xs/Randist_wrap.1.15.c
 xs/Randist_wrap.1.16.c
 xs/Randist_wrap.2.0.c
@@ -1091,6 +1184,7 @@ xs/Randist_wrap.2.2.c
 xs/Randist_wrap.2.3.c
 xs/Randist_wrap.2.4.c
 xs/Randist_wrap.2.5.c
+xs/Randist_wrap.2.6.c
 xs/RNG_wrap.1.15.c
 xs/RNG_wrap.1.16.c
 xs/RNG_wrap.2.0.c
@@ -1100,6 +1194,7 @@ xs/RNG_wrap.2.2.c
 xs/RNG_wrap.2.3.c
 xs/RNG_wrap.2.4.c
 xs/RNG_wrap.2.5.c
+xs/RNG_wrap.2.6.c
 xs/Roots_wrap.1.15.c
 xs/Roots_wrap.1.16.c
 xs/Roots_wrap.2.0.c
@@ -1109,6 +1204,7 @@ xs/Roots_wrap.2.2.c
 xs/Roots_wrap.2.3.c
 xs/Roots_wrap.2.4.c
 xs/Roots_wrap.2.5.c
+xs/Roots_wrap.2.6.c
 xs/Rstat_wrap.2.0.c
 xs/Rstat_wrap.2.1.c
 xs/Rstat_wrap.2.2.1.c
@@ -1116,6 +1212,7 @@ xs/Rstat_wrap.2.2.c
 xs/Rstat_wrap.2.3.c
 xs/Rstat_wrap.2.4.c
 xs/Rstat_wrap.2.5.c
+xs/Rstat_wrap.2.6.c
 xs/SF_wrap.1.15.c
 xs/SF_wrap.1.16.c
 xs/SF_wrap.2.0.c
@@ -1125,6 +1222,7 @@ xs/SF_wrap.2.2.c
 xs/SF_wrap.2.3.c
 xs/SF_wrap.2.4.c
 xs/SF_wrap.2.5.c
+xs/SF_wrap.2.6.c
 xs/Siman_wrap.1.15.c
 xs/Siman_wrap.1.16.c
 xs/Siman_wrap.2.0.c
@@ -1134,6 +1232,7 @@ xs/Siman_wrap.2.2.c
 xs/Siman_wrap.2.3.c
 xs/Siman_wrap.2.4.c
 xs/Siman_wrap.2.5.c
+xs/Siman_wrap.2.6.c
 xs/Sort_wrap.1.15.c
 xs/Sort_wrap.1.16.c
 xs/Sort_wrap.2.0.c
@@ -1143,6 +1242,7 @@ xs/Sort_wrap.2.2.c
 xs/Sort_wrap.2.3.c
 xs/Sort_wrap.2.4.c
 xs/Sort_wrap.2.5.c
+xs/Sort_wrap.2.6.c
 xs/SparseMatrix_wrap.2.0.c
 xs/SparseMatrix_wrap.2.1.c
 xs/SparseMatrix_wrap.2.2.1.c
@@ -1150,6 +1250,7 @@ xs/SparseMatrix_wrap.2.2.c
 xs/SparseMatrix_wrap.2.3.c
 xs/SparseMatrix_wrap.2.4.c
 xs/SparseMatrix_wrap.2.5.c
+xs/SparseMatrix_wrap.2.6.c
 xs/Spline_wrap.1.15.c
 xs/Spline_wrap.1.16.c
 xs/Spline_wrap.2.0.c
@@ -1159,6 +1260,7 @@ xs/Spline_wrap.2.2.c
 xs/Spline_wrap.2.3.c
 xs/Spline_wrap.2.4.c
 xs/Spline_wrap.2.5.c
+xs/Spline_wrap.2.6.c
 xs/Statistics_wrap.1.15.c
 xs/Statistics_wrap.1.16.c
 xs/Statistics_wrap.2.0.c
@@ -1168,6 +1270,7 @@ xs/Statistics_wrap.2.2.c
 xs/Statistics_wrap.2.3.c
 xs/Statistics_wrap.2.4.c
 xs/Statistics_wrap.2.5.c
+xs/Statistics_wrap.2.6.c
 xs/Sum_wrap.1.15.c
 xs/Sum_wrap.1.16.c
 xs/Sum_wrap.2.0.c
@@ -1177,6 +1280,7 @@ xs/Sum_wrap.2.2.c
 xs/Sum_wrap.2.3.c
 xs/Sum_wrap.2.4.c
 xs/Sum_wrap.2.5.c
+xs/Sum_wrap.2.6.c
 xs/Sys_wrap.1.15.c
 xs/Sys_wrap.1.16.c
 xs/Sys_wrap.2.0.c
@@ -1186,6 +1290,7 @@ xs/Sys_wrap.2.2.c
 xs/Sys_wrap.2.3.c
 xs/Sys_wrap.2.4.c
 xs/Sys_wrap.2.5.c
+xs/Sys_wrap.2.6.c
 xs/Vector_wrap.1.15.c
 xs/Vector_wrap.1.16.c
 xs/Vector_wrap.2.0.c
@@ -1195,6 +1300,7 @@ xs/Vector_wrap.2.2.c
 xs/Vector_wrap.2.3.c
 xs/Vector_wrap.2.4.c
 xs/Vector_wrap.2.5.c
+xs/Vector_wrap.2.6.c
 xs/VectorComplex_wrap.1.15.c
 xs/VectorComplex_wrap.1.16.c
 xs/VectorComplex_wrap.2.0.c
@@ -1204,6 +1310,7 @@ xs/VectorComplex_wrap.2.2.c
 xs/VectorComplex_wrap.2.3.c
 xs/VectorComplex_wrap.2.4.c
 xs/VectorComplex_wrap.2.5.c
+xs/VectorComplex_wrap.2.6.c
 xs/Version_wrap.1.15.c
 xs/Version_wrap.1.16.c
 xs/Version_wrap.2.0.c
@@ -1213,6 +1320,7 @@ xs/Version_wrap.2.2.c
 xs/Version_wrap.2.3.c
 xs/Version_wrap.2.4.c
 xs/Version_wrap.2.5.c
+xs/Version_wrap.2.6.c
 xs/Wavelet2D_wrap.1.15.c
 xs/Wavelet2D_wrap.1.16.c
 xs/Wavelet2D_wrap.2.0.c
@@ -1222,6 +1330,7 @@ xs/Wavelet2D_wrap.2.2.c
 xs/Wavelet2D_wrap.2.3.c
 xs/Wavelet2D_wrap.2.4.c
 xs/Wavelet2D_wrap.2.5.c
+xs/Wavelet2D_wrap.2.6.c
 xs/Wavelet_wrap.1.15.c
 xs/Wavelet_wrap.1.16.c
 xs/Wavelet_wrap.2.0.c
@@ -1231,6 +1340,7 @@ xs/Wavelet_wrap.2.2.c
 xs/Wavelet_wrap.2.3.c
 xs/Wavelet_wrap.2.4.c
 xs/Wavelet_wrap.2.5.c
+xs/Wavelet_wrap.2.6.c
 xt/01-pod.t
 xt/style-trailing-space.t
 META.json


### PR DESCRIPTION
NOTE: This PR depends on #181 which should be merged first.

Set current GSL version, `GSL_CURRENT`, in `travis.yml` to version 2.6 to make sure the module is built with GSL version 2.6.
