### PR TITLE
Fix `Version.i` to not use "2.6+" for the version

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -317,6 +317,7 @@ sub check_gsl_version {
     if ($gsl_version =~ m{\A(\d+(?:\.\d+)+)}) {
         $current_version = $1;
         my @current = split /\./, $current_version;
+        print $fh "#define GSL_VERSION $current[0].$current[1]\n";
         print $fh "#define GSL_MAJOR_VERSION $current[0]\n";
         print $fh "#define GSL_MINOR_VERSION $current[1]\n";
 

--- a/swig/Version.i
+++ b/swig/Version.i
@@ -1,8 +1,8 @@
 %module "Math::GSL::Version"
+%include "system.i"
 %{
     #include "gsl/gsl_types.h"
     #include "gsl/gsl_version.h"
 %}
 %ignore gsl_version;
 %include "gsl/gsl_types.h"
-%include "gsl/gsl_version.h"


### PR DESCRIPTION
`Version.i` included `gsl_version.h` which had defined `GSL_VERSION` as `2.6+`. This caused the test `t/00-load.t` to fail with error *"Invalid version format (non-numeric data)"*. This was because of the "+" at the end of "2.6+". To fix this, we can instead define the version as "2.6" in `system.i` and avoid include `gsl_version.h` in `Version.i`.