### PR TITLE
Make test `t/SparseMatrix.t` pass

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -317,6 +317,7 @@ sub check_gsl_version {
     if ($gsl_version =~ m{\A(\d+(?:\.\d+)+)}) {
         $current_version = $1;
         my @current = split /\./, $current_version;
+        print $fh "#define GSL_VERSION $current[0].$current[1]\n";
         print $fh "#define GSL_MAJOR_VERSION $current[0]\n";
         print $fh "#define GSL_MINOR_VERSION $current[1]\n";
 

--- a/swig/SparseMatrix.i
+++ b/swig/SparseMatrix.i
@@ -11,5 +11,6 @@
 
 
 %include "gsl/gsl_spmatrix.h"
+%include "gsl/gsl_spmatrix_double.h"
 
 %include "../pod/SparseMatrix.pod"

--- a/swig/Version.i
+++ b/swig/Version.i
@@ -1,8 +1,8 @@
 %module "Math::GSL::Version"
+%include "system.i"
 %{
     #include "gsl/gsl_types.h"
     #include "gsl/gsl_version.h"
 %}
 %ignore gsl_version;
 %include "gsl/gsl_types.h"
-%include "gsl/gsl_version.h"


### PR DESCRIPTION
Note: This PR depends on #183 which should be merged first.

The include file `gsl_spmatrix.h` was split up in GSL version 2.6, which should be reflected in `swig/SparseMatrix.i`. I am not sure about which of the sub headers to include. But including `gsl_spmatrix_double.h` at least makes `t/SparseMatrix.t` pass.

