### PR TITLE
Add `gsl_blas_types.h` to `Matrix.i` and `MatrixComplex.i`

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -317,6 +317,7 @@ sub check_gsl_version {
     if ($gsl_version =~ m{\A(\d+(?:\.\d+)+)}) {
         $current_version = $1;
         my @current = split /\./, $current_version;
+        print $fh "#define GSL_VERSION $current[0].$current[1]\n";
         print $fh "#define GSL_MAJOR_VERSION $current[0]\n";
         print $fh "#define GSL_MINOR_VERSION $current[1]\n";
 

--- a/swig/Matrix.i
+++ b/swig/Matrix.i
@@ -10,6 +10,7 @@
 
 %{
     #include "gsl/gsl_inline.h"
+    #include "gsl/gsl_blas_types.h"
     #include "gsl/gsl_matrix.h"
     #include "gsl/gsl_complex.h"
     #include "gsl/gsl_vector_double.h"
@@ -22,6 +23,7 @@
 %}
 
 %include "gsl/gsl_inline.h"
+%include "gsl/gsl_blas_types.h"
 %include "gsl/gsl_matrix.h"
 %include "gsl/gsl_complex.h"
 %include "gsl/gsl_vector_double.h"

--- a/swig/MatrixComplex.i
+++ b/swig/MatrixComplex.i
@@ -10,6 +10,7 @@
 
 %{
     #include "gsl/gsl_inline.h"
+    #include "gsl/gsl_blas_types.h"
     #include "gsl/gsl_matrix.h"
     #include "gsl/gsl_complex.h"
     #include "gsl/gsl_vector_double.h"
@@ -17,6 +18,7 @@
 %}
 
 %include "gsl/gsl_inline.h"
+%include "gsl/gsl_blas_types.h"
 %include "gsl/gsl_matrix.h"
 %include "gsl/gsl_complex.h"
 %include "gsl/gsl_vector_double.h"

--- a/swig/SparseMatrix.i
+++ b/swig/SparseMatrix.i
@@ -11,5 +11,6 @@
 
 
 %include "gsl/gsl_spmatrix.h"
+%include "gsl/gsl_spmatrix_double.h"
 
 %include "../pod/SparseMatrix.pod"

--- a/swig/Version.i
+++ b/swig/Version.i
@@ -1,8 +1,8 @@
 %module "Math::GSL::Version"
+%include "system.i"
 %{
     #include "gsl/gsl_types.h"
     #include "gsl/gsl_version.h"
 %}
 %ignore gsl_version;
 %include "gsl/gsl_types.h"
-%include "gsl/gsl_version.h"


### PR DESCRIPTION
Note: This PR depends on #184 which should be merged first.

In GSL 2.6 `gsl_matrix_tricpy()` in `gsl_matrix_double.h` has got a new signature that depends on the include file `gsl_blas_types.h`. This include file is not included from `gsl_matrix_double.h` in GSL 2.5. In order for the generated C files for GSL 2.5 to compile we need to include `gsl_blas_types.h` in the interface files `Matrix.i` and `MatrixComplex.i`.
