### PR TITLE
Handle new type `gsl_spmatrix_pool_node` in GSL 2.6

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -317,6 +317,7 @@ sub check_gsl_version {
     if ($gsl_version =~ m{\A(\d+(?:\.\d+)+)}) {
         $current_version = $1;
         my @current = split /\./, $current_version;
+        print $fh "#define GSL_VERSION $current[0].$current[1]\n";
         print $fh "#define GSL_MAJOR_VERSION $current[0]\n";
         print $fh "#define GSL_MINOR_VERSION $current[1]\n";
 

--- a/inc/Ver2Func.pm
+++ b/inc/Ver2Func.pm
@@ -296,6 +296,12 @@ my @ver2func = (
         ],
     },
     "2.6" => {
+        new => [
+            qw/
+	      ^gsl_spmatrix_pool_node$
+	      ^gsl_spmatrix_pool$
+              /
+            ]
     }
 );
 

--- a/swig/Matrix.i
+++ b/swig/Matrix.i
@@ -10,6 +10,7 @@
 
 %{
     #include "gsl/gsl_inline.h"
+    #include "gsl/gsl_blas_types.h"
     #include "gsl/gsl_matrix.h"
     #include "gsl/gsl_complex.h"
     #include "gsl/gsl_vector_double.h"
@@ -22,6 +23,7 @@
 %}
 
 %include "gsl/gsl_inline.h"
+%include "gsl/gsl_blas_types.h"
 %include "gsl/gsl_matrix.h"
 %include "gsl/gsl_complex.h"
 %include "gsl/gsl_vector_double.h"

--- a/swig/MatrixComplex.i
+++ b/swig/MatrixComplex.i
@@ -10,6 +10,7 @@
 
 %{
     #include "gsl/gsl_inline.h"
+    #include "gsl/gsl_blas_types.h"
     #include "gsl/gsl_matrix.h"
     #include "gsl/gsl_complex.h"
     #include "gsl/gsl_vector_double.h"
@@ -17,6 +18,7 @@
 %}
 
 %include "gsl/gsl_inline.h"
+%include "gsl/gsl_blas_types.h"
 %include "gsl/gsl_matrix.h"
 %include "gsl/gsl_complex.h"
 %include "gsl/gsl_vector_double.h"

--- a/swig/SparseMatrix.i
+++ b/swig/SparseMatrix.i
@@ -11,5 +11,6 @@
 
 
 %include "gsl/gsl_spmatrix.h"
+%include "gsl/gsl_spmatrix_double.h"
 
 %include "../pod/SparseMatrix.pod"

--- a/swig/Version.i
+++ b/swig/Version.i
@@ -1,8 +1,8 @@
 %module "Math::GSL::Version"
+%include "system.i"
 %{
     #include "gsl/gsl_types.h"
     #include "gsl/gsl_version.h"
 %}
 %ignore gsl_version;
 %include "gsl/gsl_types.h"
-%include "gsl/gsl_version.h"


### PR DESCRIPTION
Note: This PR depends on #185 which should be merged first.

GSL 2.6 introduces a new type `gsl_spmatrix_pool_node` in  `gsl/gsl_spmatrix.h`. Add it to the `new` array in `Ver2Func.pm`.

