### PR TITLE
Add version information from swig command line.

### DIFF
--- a/inc/GSLBuilder.pm
+++ b/inc/GSLBuilder.pm
@@ -179,6 +179,17 @@ sub swig_binary_name {
     return "swig";
 }
 
+sub reformat_version {
+    my ( $ver) = @_;
+
+    my ($major, $minor) = $ver =~ /^(\d+)\.(\d+)/;
+    if (($major > 999) || ( $minor > 999 )) {
+        die "Unexpected swig version: $ver";
+    }
+    my $numerical_ver = (sprintf "%03d", $major) . ( sprintf "%03d", $minor );
+    return ($major, $minor, $numerical_ver);
+}
+
 # Invoke swig with -perl -outdir and other options.
 sub compile_swig {
     my ($self, $file, $c_file, $ver) = @_;
@@ -194,6 +205,9 @@ sub compile_swig {
 
     my @swig       = swig_binary_name(), defined($p->{swig}) ? ($self->split_like_shell($p->{swig})) : ();
     my @swig_flags = defined($p->{swig_flags}) ? $self->split_like_shell($p->{swig_flags}) : ();
+    my ($major, $minor, $numerical_ver) = reformat_version($ver);
+    push @swig_flags, "-DMG_GSL_MAJOR_VERSION=$major",
+      "-DMG_GSL_MINOR_VERSION=$minor", "-DMG_GSL_VERSION=$numerical_ver";
 
     my $blib_lib = catdir(qw/blib lib/);
     my $gsldir = catdir('pm', qw/Math GSL/);


### PR DESCRIPTION
Adds macro definitions for the GSL version that is currently being built from the command line in `compile_swig()` in `GSLBuilder.pm`. This will enable the interface files to check which GSL version they are supposed to be used for. This feature can be used to include new include files into the interface file based on the GSL version or it can be used for example to exclude or rewrite C definitions or types. 

This feature is an alternative/extension of the `rename.i` framework in `Ver2Func.pm`. It should in some cases be much simpler to use then listing all symbols in `Ver2Func.pm`.