### PR TITLE
Bump version number for Math/GSL.pm to 0.41

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Search CPAN http://search.cpan.org/dist/Math::GSL
 # Developer information
 
 - [Upgrading to a new GSL version](developer/wiki/Upgrade.md)
+- [Uploading a new CPAN distribution](developer/wiki/Upload.md)
 
 # Copyright and Licence
 

--- a/developer/wiki/Upload.md
+++ b/developer/wiki/Upload.md
@@ -1,0 +1,29 @@
+# Uploading a new CPAN distribution
+
+## Bump version number in `Math/GSL.pm`
+
+- Edit the file `lib/Math/GSL.pm` and change the version number at
+line 29:
+
+```
+our $VERSION = '0.41';  # <-- increase the version number
+```
+
+## Build the CPAN distribution
+
+```
+cd docker 
+./build_image.sh
+./run.sh 2.6  # <-- Uses GSL version 2.6 to build the distribution
+```
+after `run.sh` finishes you are left in the bash shell of the docker
+container with a file `Math-GSL-xx.yy.tar.gz`, where xx.yy corresponds
+to the version you chose in the previous step.
+
+## Upload the distribution
+
+- Go to the PAUSE upload server
+
+https://pause.perl.org/pause/authenquery?ACTION=add_uri
+
+and upload the generated tarball (e.g. `Math-GSL-0.41.tar.gz`)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu:20.04
+SHELL ["/bin/bash", "-c"]
+RUN apt-get update && \ 
+    apt-get install -y build-essential curl g++ git cpanminus \
+                       vim sudo wget clang swig autoconf libtool
+COPY entrypoint.sh .
+ENTRYPOINT ["./entrypoint.sh"] 

--- a/docker/build_image.sh
+++ b/docker/build_image.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+
+docker build -t math-gsl-ubuntu-2004 .

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,41 @@
+#! /bin/bash
+
+if (( $# != 1)) || [[ -z $1 ]] ; then
+    echo "Bad arguments. Please specify version of GSL as first argument"
+    exit
+else
+    echo "Using GSL_VERSION=$1 ..."
+    export GSL_VERSION="$1"
+fi
+GSL_MIRROR=http://mirrors.kernel.org/gnu/gsl
+CURDIR="$PWD"
+GSL_INST_DIR="/tmp/gsl"
+GSL_SRC_DIR="$CURDIR/gsl"
+TARBALL_GSL=gsl-"$GSL_VERSION"
+TARBALL="$TARBALL_GSL".tar.gz
+
+install_gsl() {
+    mkdir -p "$GSL_SRC_DIR"
+    cd "$GSL_SRC_DIR"
+    wget "$GSL_MIRROR"/"$TARBALL" --retry-connrefused --timeout=900 
+    tar zxvf "$TARBALL"
+    cd "$TARBALL_GSL"
+    ./configure --prefix "$GSL_INST_DIR"/"$TARBALL_GSL"
+    make -j$(nproc)
+    make install
+    cd "$CURDIR"
+}
+
+install_gsl
+export LD_LIBRARY_PATH="$GSL_INST_DIR"/"$TARBALL_GSL"/lib
+export PATH="$GSL_INST_DIR"/"$TARBALL_GSL"/bin:"$PATH"
+git clone https://github.com/leto/math--gsl.git
+cd math--gsl
+cpanm Module::Build
+perl Build.PL
+./Build installdeps --cpan_client cpanm
+./Build
+./Build test
+./Build dist
+
+exec bash

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,3 +1,11 @@
 #! /bin/bash
 
-docker run -it math-gsl-ubuntu-2004 2.6
+if (( $# != 1)) || [[ -z $1 ]] ; then
+    echo "Bad arguments. Please specify version of GSL as first argument"
+    exit
+else
+    echo "Using GSL=$1 ..."
+    GSL_VERSION="$1"
+fi
+
+docker run -it math-gsl-ubuntu-2004 "$GSL_VERSION"

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+
+docker run -it math-gsl-ubuntu-2004 2.6

--- a/lib/Math/GSL.pm
+++ b/lib/Math/GSL.pm
@@ -26,7 +26,7 @@ our %EXPORT_TAGS = ( all => \@EXPORT_OK, );
 
 our ($GSL_PREC_DOUBLE, $GSL_PREC_SINGLE, $GSL_PREC_APPROX ) = 0 .. 2;
 our $GSL_MODE_DEFAULT = $GSL_PREC_DOUBLE;
-our $VERSION = '0.40';
+our $VERSION = '0.41';
 
 =head1 NAME
 


### PR DESCRIPTION
Note that this PR depends on #198, which should be merged first