### PR TITLE
Add support for Alien::GSL

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -26,11 +26,13 @@ use lib 'inc';
 use GSLBuilder;
 use Ver2Func;
 use File::Spec::Functions qw/:ALL/;
+use Alien::GSL;
 
 our $MIN_GSL_VERSION = "1.15";
 
 my $gsl_conf;
 
+check_alien_gsl_share_dir();
 $gsl_conf = check_gsl_version();
 $gsl_conf = check_gsl_version_pkgconfig() if not $gsl_conf;
 
@@ -240,6 +242,14 @@ sub try_cflags {
     }
     print "no\n";
     return '';
+}
+
+sub check_alien_gsl_share_dir {
+    if (Alien::GSL->install_type eq "share") {
+        my $dist_dir = Alien::GSL->dist_dir;
+        my $bin_dir = File::Spec->catfile( $dist_dir, "bin" );
+        $ENV{PATH} .= ":$bin_dir";
+    }
 }
 
 sub check_gsl_version_pkgconfig {

--- a/_travis/before_install.sh
+++ b/_travis/before_install.sh
@@ -203,6 +203,7 @@ if [ -n "$TRAVIS_BUILD_DIR" ] ; then
     (
         set -v
 	cpanm -n PkgConfig
+	cpanm Alien::GSL
 	cd $TRAVIS_BUILD_DIR
 
 	export LD_LIBRARY_PATH=$GSL_INST_DIR/gsl-${GSL_CURRENT}/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}


### PR DESCRIPTION
Solves issue #212. Adds the `bin` dir in the sharedir of `Alien::GSL` to `PATH` if the user has not installed `libgsl.so` on their system.  