### PR TITLE
Fixed missing dependencies in `Dockerfile`

### DIFF
--- a/developer/docker/Dockerfile
+++ b/developer/docker/Dockerfile
@@ -2,6 +2,9 @@ FROM ubuntu:20.04
 SHELL ["/bin/bash", "-c"]
 RUN apt-get update && \ 
     apt-get install -y build-essential curl g++ git cpanminus \
-                       vim sudo wget clang swig autoconf libtool
+        vim sudo wget clang swig autoconf libtool libssl-dev libz-dev
+
+ARG home=/root
+WORKDIR $home
 COPY entrypoint.sh .
 ENTRYPOINT ["./entrypoint.sh"] 

--- a/developer/docker/entrypoint.sh
+++ b/developer/docker/entrypoint.sh
@@ -31,11 +31,16 @@ export LD_LIBRARY_PATH="$GSL_INST_DIR"/"$TARBALL_GSL"/lib
 export PATH="$GSL_INST_DIR"/"$TARBALL_GSL"/bin:"$PATH"
 git clone https://github.com/leto/math--gsl.git
 cd math--gsl
+cpanm -n Net::SSLeay
+cpanm Alien::GSL
 cpanm Module::Build
 perl Build.PL
 ./Build installdeps --cpan_client cpanm
 ./Build
 ./Build test
 ./Build dist
+mkdir -p /tmp/dist
+mv *.tar.gz /tmp/dist
 
-exec bash
+# Uncomment the following line if you do not want to immediately remove the container..
+# exec bash

--- a/developer/docker/entrypoint.sh
+++ b/developer/docker/entrypoint.sh
@@ -31,6 +31,11 @@ export LD_LIBRARY_PATH="$GSL_INST_DIR"/"$TARBALL_GSL"/lib
 export PATH="$GSL_INST_DIR"/"$TARBALL_GSL"/bin:"$PATH"
 git clone https://github.com/leto/math--gsl.git
 cd math--gsl
+# NOTE: On Ubuntu 20.04 there is some test failures when installing Net::SSLeay
+#       See: https://rt.cpan.org/Ticket/Display.html?id=132425
+#       There is already a patch ready, so I guess the problem with be fixed
+#       in Ubuntu 20.10. For now, we just install Net::SSLeay without running the
+#       tests.
 cpanm -n Net::SSLeay
 cpanm Alien::GSL
 cpanm Module::Build

--- a/developer/docker/get_tarball.sh
+++ b/developer/docker/get_tarball.sh
@@ -1,4 +1,0 @@
-#! /bin/bash
-
-version=$(perl -nE '/our\s+\$VERSION\s*=\s*.(\d+\.\d+)/ and do {print $1; exit}' ../../lib/Math/GSL.pm)
-docker cp math-gsl-ubuntu-2004:/math--gsl/Math-GSL-"$version".tar.gz .

--- a/developer/docker/run.sh
+++ b/developer/docker/run.sh
@@ -8,4 +8,4 @@ else
     GSL_VERSION="$1"
 fi
 
-docker run --name math-gsl-ubuntu-2004 -it math-gsl-ubuntu-2004 "$GSL_VERSION"
+docker run --rm -v "$PWD":/tmp/dist --name math-gsl-ubuntu-2004 -it math-gsl-ubuntu-2004 "$GSL_VERSION"

--- a/developer/wiki/Upload.md
+++ b/developer/wiki/Upload.md
@@ -29,16 +29,9 @@ cd developer/docker
 ./build_image.sh
 ./run.sh 2.6  # <-- Uses GSL version 2.6 to build the distribution
 ```
-after `run.sh` finishes you are left in the bash shell of the docker
-container with a file `Math-GSL-xx.yy.tar.gz`, where xx.yy corresponds
-to the version you chose in the previous step.
-
-Go to another shell window on the host machine and copy the generated
-tarball from the docker image to the host machine:
-
-```
-./get_tarball.sh
-```
+after `run.sh` there should be a distribution tarball
+`Math-GSL-xx.yy.tar.gz`, in the current directory. Here, xx.yy
+corresponds the current version, i.e., `$Math::GSL::VERSION`.
 
 ## Upload the distribution
 


### PR DESCRIPTION
The `Alien::GSL` module requires `libssl-dev` and `libz-dev` packages. Also simplified the docker script such that the `get_tarball.sh` script is no longer needed.