### PR TITLE
Fixes issue #220. Link with `libperl.dll.a` when creating shared object on MSYS2

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -65,6 +65,12 @@ if ( GSLBuilder::is_cygwin()  && $Config{shrpenv} =~ m{\Aenv LD_RUN_PATH=(.*)\Z}
     $ldflags .= " -L$1 -lperl";
     # Should we check the 32-ness?
     $swig_flags = '-DNEED_LONG';
+} elsif (GSLBuilder::is_msys()) {
+    # It is not possible to leave a symbol in a PE DLL undefined at link time, 
+    # to be satisfied at runtime, as it is instead possible with most UNIX shared objects
+    # See https://autotools.io/libtool/windows.html
+    # So we need to link with libperl.dll.a on MSYS2
+    $ldflags .= " -L$Config{archlib}/CORE -lperl";
 } elsif (GSLBuilder::is_darwin()) {
     $ldflags .= ' -bundle -flat_namespace ';
 }

--- a/inc/GSLBuilder.pm
+++ b/inc/GSLBuilder.pm
@@ -253,6 +253,7 @@ sub compile_swig {
 sub is_windows { $^O =~ /MSWin32/i }
 sub is_darwin  { $^O =~ /darwin/i  }
 sub is_cygwin  { $^O =~ /cygwin/i }
+sub is_msys  { $^O eq "msys" }
 
 # Windows fixes courtesy of <sisyphus@cpan.org>
 sub link_c {


### PR DESCRIPTION
Fixes #220. 

According to [this](https://autotools.io/libtool/windows.html) page, it is not possible to leave a symbol in a PE DLL undefined at link time, to be satisfied at runtime, as it is instead possible with most UNIX shared objects. So we need to link with `libperl.dll.a` on MSYS2.