### PR TITLE
First step to add support for GSL 2.7.

### DIFF
--- a/inc/Ver2Func.pm
+++ b/inc/Ver2Func.pm
@@ -397,7 +397,14 @@ my @ver2func = (
               ^gsl_matrix_uint_scale_columns$
               /
             ]
+    },
+    "2.7" => {
+        new => [
+            qw/
+              /
+        ]
     }
+
 );
 
 my ( %index, @info, @versions );


### PR DESCRIPTION
[GSL 2.7 was released June 1st, 2021](https://www.mail-archive.com/help-gsl@gnu.org/msg05459.html). I am starting to add support for this. First step is to make `perl Build.PL` run. After this change I am able to run `perl Build.PL` and then `./Build` without failures.