### PR TITLE
Fixes issue #231.

### DIFF
--- a/inc/Ver2Func.pm
+++ b/inc/Ver2Func.pm
@@ -397,7 +397,14 @@ my @ver2func = (
               ^gsl_matrix_uint_scale_columns$
               /
             ]
+    },
+    "2.7" => {
+        new => [
+            qw/
+              /
+        ]
     }
+
 );
 
 my ( %index, @info, @versions );

--- a/swig/SparseMatrix.i
+++ b/swig/SparseMatrix.i
@@ -11,7 +11,7 @@
 
 #if MG_GSL_NUM_VERSION >= 002006
 // ignore gsl_spmatrix_uchar_norm1, gsl_spmatrix_char_norm1, ...
-  %rename("%(regex:/^gsl_spmatrix_.+_norm1$/$ignore/)s") "";
+  %rename("%(regex:/^gsl_spmatrix_u.*_norm1$/$ignore/)s") "";
   %include "gsl/gsl_spmatrix.h"
   %include "gsl/gsl_spmatrix_double.h"
   %include "gsl/gsl_spmatrix_complex_long_double.h"

--- a/swig/SparseMatrix.i
+++ b/swig/SparseMatrix.i
@@ -10,6 +10,8 @@
 %}
 
 #if MG_GSL_NUM_VERSION >= 002006
+// ignore gsl_spmatrix_uchar_norm1, gsl_spmatrix_char_norm1, ...
+  %rename("%(regex:/^gsl_spmatrix_.+_norm1$/$ignore/)s") "";
   %include "gsl/gsl_spmatrix.h"
   %include "gsl/gsl_spmatrix_double.h"
   %include "gsl/gsl_spmatrix_complex_long_double.h"


### PR DESCRIPTION
This PR builds on #230, which should be merged first.

Fixes issue #231. Ignore all `gsl_spmatrix_xxxx_norm1()` functions for now. They don't exist in `libgsl.so` so then Perl cannot use them either.