### PR TITLE
Update MANIFEST for GSL 2.7

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -100,6 +100,7 @@ pm/Math/GSL/BLAS.pm.2.3
 pm/Math/GSL/BLAS.pm.2.4
 pm/Math/GSL/BLAS.pm.2.5
 pm/Math/GSL/BLAS.pm.2.6
+pm/Math/GSL/BLAS.pm.2.7
 pm/Math/GSL/BSpline.pm.1.15
 pm/Math/GSL/BSpline.pm.1.16
 pm/Math/GSL/BSpline.pm.2.0
@@ -110,6 +111,7 @@ pm/Math/GSL/BSpline.pm.2.3
 pm/Math/GSL/BSpline.pm.2.4
 pm/Math/GSL/BSpline.pm.2.5
 pm/Math/GSL/BSpline.pm.2.6
+pm/Math/GSL/BSpline.pm.2.7
 pm/Math/GSL/CBLAS.pm.1.15
 pm/Math/GSL/CBLAS.pm.1.16
 pm/Math/GSL/CBLAS.pm.2.0
@@ -120,6 +122,7 @@ pm/Math/GSL/CBLAS.pm.2.3
 pm/Math/GSL/CBLAS.pm.2.4
 pm/Math/GSL/CBLAS.pm.2.5
 pm/Math/GSL/CBLAS.pm.2.6
+pm/Math/GSL/CBLAS.pm.2.7
 pm/Math/GSL/CDF.pm.1.15
 pm/Math/GSL/CDF.pm.1.16
 pm/Math/GSL/CDF.pm.2.0
@@ -130,6 +133,7 @@ pm/Math/GSL/CDF.pm.2.3
 pm/Math/GSL/CDF.pm.2.4
 pm/Math/GSL/CDF.pm.2.5
 pm/Math/GSL/CDF.pm.2.6
+pm/Math/GSL/CDF.pm.2.7
 pm/Math/GSL/Chebyshev.pm.1.15
 pm/Math/GSL/Chebyshev.pm.1.16
 pm/Math/GSL/Chebyshev.pm.2.0
@@ -140,6 +144,7 @@ pm/Math/GSL/Chebyshev.pm.2.3
 pm/Math/GSL/Chebyshev.pm.2.4
 pm/Math/GSL/Chebyshev.pm.2.5
 pm/Math/GSL/Chebyshev.pm.2.6
+pm/Math/GSL/Chebyshev.pm.2.7
 pm/Math/GSL/Combination.pm.1.15
 pm/Math/GSL/Combination.pm.1.16
 pm/Math/GSL/Combination.pm.2.0
@@ -150,6 +155,7 @@ pm/Math/GSL/Combination.pm.2.3
 pm/Math/GSL/Combination.pm.2.4
 pm/Math/GSL/Combination.pm.2.5
 pm/Math/GSL/Combination.pm.2.6
+pm/Math/GSL/Combination.pm.2.7
 pm/Math/GSL/Complex.pm.1.15
 pm/Math/GSL/Complex.pm.1.16
 pm/Math/GSL/Complex.pm.2.0
@@ -160,6 +166,7 @@ pm/Math/GSL/Complex.pm.2.3
 pm/Math/GSL/Complex.pm.2.4
 pm/Math/GSL/Complex.pm.2.5
 pm/Math/GSL/Complex.pm.2.6
+pm/Math/GSL/Complex.pm.2.7
 pm/Math/GSL/Const.pm.1.15
 pm/Math/GSL/Const.pm.1.16
 pm/Math/GSL/Const.pm.2.0
@@ -170,6 +177,7 @@ pm/Math/GSL/Const.pm.2.3
 pm/Math/GSL/Const.pm.2.4
 pm/Math/GSL/Const.pm.2.5
 pm/Math/GSL/Const.pm.2.6
+pm/Math/GSL/Const.pm.2.7
 pm/Math/GSL/Deriv.pm.1.15
 pm/Math/GSL/Deriv.pm.1.16
 pm/Math/GSL/Deriv.pm.2.0
@@ -180,6 +188,7 @@ pm/Math/GSL/Deriv.pm.2.3
 pm/Math/GSL/Deriv.pm.2.4
 pm/Math/GSL/Deriv.pm.2.5
 pm/Math/GSL/Deriv.pm.2.6
+pm/Math/GSL/Deriv.pm.2.7
 pm/Math/GSL/DHT.pm.1.15
 pm/Math/GSL/DHT.pm.1.16
 pm/Math/GSL/DHT.pm.2.0
@@ -190,6 +199,7 @@ pm/Math/GSL/DHT.pm.2.3
 pm/Math/GSL/DHT.pm.2.4
 pm/Math/GSL/DHT.pm.2.5
 pm/Math/GSL/DHT.pm.2.6
+pm/Math/GSL/DHT.pm.2.7
 pm/Math/GSL/Diff.pm.1.15
 pm/Math/GSL/Diff.pm.1.16
 pm/Math/GSL/Diff.pm.2.0
@@ -200,6 +210,7 @@ pm/Math/GSL/Diff.pm.2.3
 pm/Math/GSL/Diff.pm.2.4
 pm/Math/GSL/Diff.pm.2.5
 pm/Math/GSL/Diff.pm.2.6
+pm/Math/GSL/Diff.pm.2.7
 pm/Math/GSL/Eigen.pm.1.15
 pm/Math/GSL/Eigen.pm.1.16
 pm/Math/GSL/Eigen.pm.2.0
@@ -210,6 +221,7 @@ pm/Math/GSL/Eigen.pm.2.3
 pm/Math/GSL/Eigen.pm.2.4
 pm/Math/GSL/Eigen.pm.2.5
 pm/Math/GSL/Eigen.pm.2.6
+pm/Math/GSL/Eigen.pm.2.7
 pm/Math/GSL/Errno.pm.1.15
 pm/Math/GSL/Errno.pm.1.16
 pm/Math/GSL/Errno.pm.2.0
@@ -220,6 +232,7 @@ pm/Math/GSL/Errno.pm.2.3
 pm/Math/GSL/Errno.pm.2.4
 pm/Math/GSL/Errno.pm.2.5
 pm/Math/GSL/Errno.pm.2.6
+pm/Math/GSL/Errno.pm.2.7
 pm/Math/GSL/FFT.pm.1.15
 pm/Math/GSL/FFT.pm.1.16
 pm/Math/GSL/FFT.pm.2.0
@@ -230,6 +243,7 @@ pm/Math/GSL/FFT.pm.2.3
 pm/Math/GSL/FFT.pm.2.4
 pm/Math/GSL/FFT.pm.2.5
 pm/Math/GSL/FFT.pm.2.6
+pm/Math/GSL/FFT.pm.2.7
 pm/Math/GSL/Fit.pm.1.15
 pm/Math/GSL/Fit.pm.1.16
 pm/Math/GSL/Fit.pm.2.0
@@ -240,6 +254,7 @@ pm/Math/GSL/Fit.pm.2.3
 pm/Math/GSL/Fit.pm.2.4
 pm/Math/GSL/Fit.pm.2.5
 pm/Math/GSL/Fit.pm.2.6
+pm/Math/GSL/Fit.pm.2.7
 pm/Math/GSL/Heapsort.pm.1.15
 pm/Math/GSL/Heapsort.pm.1.16
 pm/Math/GSL/Heapsort.pm.2.0
@@ -250,6 +265,7 @@ pm/Math/GSL/Heapsort.pm.2.3
 pm/Math/GSL/Heapsort.pm.2.4
 pm/Math/GSL/Heapsort.pm.2.5
 pm/Math/GSL/Heapsort.pm.2.6
+pm/Math/GSL/Heapsort.pm.2.7
 pm/Math/GSL/Histogram.pm.1.15
 pm/Math/GSL/Histogram.pm.1.16
 pm/Math/GSL/Histogram.pm.2.0
@@ -260,6 +276,7 @@ pm/Math/GSL/Histogram.pm.2.3
 pm/Math/GSL/Histogram.pm.2.4
 pm/Math/GSL/Histogram.pm.2.5
 pm/Math/GSL/Histogram.pm.2.6
+pm/Math/GSL/Histogram.pm.2.7
 pm/Math/GSL/Histogram2D.pm.1.15
 pm/Math/GSL/Histogram2D.pm.1.16
 pm/Math/GSL/Histogram2D.pm.2.0
@@ -270,6 +287,7 @@ pm/Math/GSL/Histogram2D.pm.2.3
 pm/Math/GSL/Histogram2D.pm.2.4
 pm/Math/GSL/Histogram2D.pm.2.5
 pm/Math/GSL/Histogram2D.pm.2.6
+pm/Math/GSL/Histogram2D.pm.2.7
 pm/Math/GSL/IEEEUtils.pm.1.15
 pm/Math/GSL/IEEEUtils.pm.1.16
 pm/Math/GSL/IEEEUtils.pm.2.0
@@ -280,6 +298,7 @@ pm/Math/GSL/IEEEUtils.pm.2.3
 pm/Math/GSL/IEEEUtils.pm.2.4
 pm/Math/GSL/IEEEUtils.pm.2.5
 pm/Math/GSL/IEEEUtils.pm.2.6
+pm/Math/GSL/IEEEUtils.pm.2.7
 pm/Math/GSL/Integration.pm.1.15
 pm/Math/GSL/Integration.pm.1.16
 pm/Math/GSL/Integration.pm.2.0
@@ -290,6 +309,7 @@ pm/Math/GSL/Integration.pm.2.3
 pm/Math/GSL/Integration.pm.2.4
 pm/Math/GSL/Integration.pm.2.5
 pm/Math/GSL/Integration.pm.2.6
+pm/Math/GSL/Integration.pm.2.7
 pm/Math/GSL/Interp.pm.1.15
 pm/Math/GSL/Interp.pm.1.16
 pm/Math/GSL/Interp.pm.2.0
@@ -300,6 +320,7 @@ pm/Math/GSL/Interp.pm.2.3
 pm/Math/GSL/Interp.pm.2.4
 pm/Math/GSL/Interp.pm.2.5
 pm/Math/GSL/Interp.pm.2.6
+pm/Math/GSL/Interp.pm.2.7
 pm/Math/GSL/Linalg.pm.1.15
 pm/Math/GSL/Linalg.pm.1.16
 pm/Math/GSL/Linalg.pm.2.0
@@ -310,6 +331,7 @@ pm/Math/GSL/Linalg.pm.2.3
 pm/Math/GSL/Linalg.pm.2.4
 pm/Math/GSL/Linalg.pm.2.5
 pm/Math/GSL/Linalg.pm.2.6
+pm/Math/GSL/Linalg.pm.2.7
 pm/Math/GSL/Machine.pm.1.15
 pm/Math/GSL/Machine.pm.1.16
 pm/Math/GSL/Machine.pm.2.0
@@ -320,6 +342,7 @@ pm/Math/GSL/Machine.pm.2.3
 pm/Math/GSL/Machine.pm.2.4
 pm/Math/GSL/Machine.pm.2.5
 pm/Math/GSL/Machine.pm.2.6
+pm/Math/GSL/Machine.pm.2.7
 pm/Math/GSL/Matrix.pm.1.15
 pm/Math/GSL/Matrix.pm.1.16
 pm/Math/GSL/Matrix.pm.2.0
@@ -330,6 +353,7 @@ pm/Math/GSL/Matrix.pm.2.3
 pm/Math/GSL/Matrix.pm.2.4
 pm/Math/GSL/Matrix.pm.2.5
 pm/Math/GSL/Matrix.pm.2.6
+pm/Math/GSL/Matrix.pm.2.7
 pm/Math/GSL/MatrixComplex.pm.1.15
 pm/Math/GSL/MatrixComplex.pm.1.16
 pm/Math/GSL/MatrixComplex.pm.2.0
@@ -340,6 +364,7 @@ pm/Math/GSL/MatrixComplex.pm.2.3
 pm/Math/GSL/MatrixComplex.pm.2.4
 pm/Math/GSL/MatrixComplex.pm.2.5
 pm/Math/GSL/MatrixComplex.pm.2.6
+pm/Math/GSL/MatrixComplex.pm.2.7
 pm/Math/GSL/Min.pm.1.15
 pm/Math/GSL/Min.pm.1.16
 pm/Math/GSL/Min.pm.2.0
@@ -350,6 +375,7 @@ pm/Math/GSL/Min.pm.2.3
 pm/Math/GSL/Min.pm.2.4
 pm/Math/GSL/Min.pm.2.5
 pm/Math/GSL/Min.pm.2.6
+pm/Math/GSL/Min.pm.2.7
 pm/Math/GSL/Monte.pm.1.15
 pm/Math/GSL/Monte.pm.1.16
 pm/Math/GSL/Monte.pm.2.0
@@ -360,6 +386,7 @@ pm/Math/GSL/Monte.pm.2.3
 pm/Math/GSL/Monte.pm.2.4
 pm/Math/GSL/Monte.pm.2.5
 pm/Math/GSL/Monte.pm.2.6
+pm/Math/GSL/Monte.pm.2.7
 pm/Math/GSL/Multifit.pm.2.1
 pm/Math/GSL/Multifit.pm.2.2
 pm/Math/GSL/Multifit.pm.2.2.1
@@ -367,6 +394,7 @@ pm/Math/GSL/Multifit.pm.2.3
 pm/Math/GSL/Multifit.pm.2.4
 pm/Math/GSL/Multifit.pm.2.5
 pm/Math/GSL/Multifit.pm.2.6
+pm/Math/GSL/Multifit.pm.2.7
 pm/Math/GSL/Multilarge.pm.2.1
 pm/Math/GSL/Multilarge.pm.2.2
 pm/Math/GSL/Multilarge.pm.2.2.1
@@ -374,6 +402,7 @@ pm/Math/GSL/Multilarge.pm.2.3
 pm/Math/GSL/Multilarge.pm.2.4
 pm/Math/GSL/Multilarge.pm.2.5
 pm/Math/GSL/Multilarge.pm.2.6
+pm/Math/GSL/Multilarge.pm.2.7
 pm/Math/GSL/Multimin.pm.1.15
 pm/Math/GSL/Multimin.pm.1.16
 pm/Math/GSL/Multimin.pm.2.0
@@ -384,6 +413,7 @@ pm/Math/GSL/Multimin.pm.2.3
 pm/Math/GSL/Multimin.pm.2.4
 pm/Math/GSL/Multimin.pm.2.5
 pm/Math/GSL/Multimin.pm.2.6
+pm/Math/GSL/Multimin.pm.2.7
 pm/Math/GSL/Multiroots.pm.1.15
 pm/Math/GSL/Multiroots.pm.1.16
 pm/Math/GSL/Multiroots.pm.2.0
@@ -394,6 +424,7 @@ pm/Math/GSL/Multiroots.pm.2.3
 pm/Math/GSL/Multiroots.pm.2.4
 pm/Math/GSL/Multiroots.pm.2.5
 pm/Math/GSL/Multiroots.pm.2.6
+pm/Math/GSL/Multiroots.pm.2.7
 pm/Math/GSL/Multiset.pm.1.15
 pm/Math/GSL/Multiset.pm.1.16
 pm/Math/GSL/Multiset.pm.2.0
@@ -404,6 +435,7 @@ pm/Math/GSL/Multiset.pm.2.3
 pm/Math/GSL/Multiset.pm.2.4
 pm/Math/GSL/Multiset.pm.2.5
 pm/Math/GSL/Multiset.pm.2.6
+pm/Math/GSL/Multiset.pm.2.7
 pm/Math/GSL/NTuple.pm.1.15
 pm/Math/GSL/NTuple.pm.1.16
 pm/Math/GSL/NTuple.pm.2.0
@@ -414,6 +446,7 @@ pm/Math/GSL/NTuple.pm.2.3
 pm/Math/GSL/NTuple.pm.2.4
 pm/Math/GSL/NTuple.pm.2.5
 pm/Math/GSL/NTuple.pm.2.6
+pm/Math/GSL/NTuple.pm.2.7
 pm/Math/GSL/ODEIV.pm.1.15
 pm/Math/GSL/ODEIV.pm.1.16
 pm/Math/GSL/ODEIV.pm.2.0
@@ -424,6 +457,7 @@ pm/Math/GSL/ODEIV.pm.2.3
 pm/Math/GSL/ODEIV.pm.2.4
 pm/Math/GSL/ODEIV.pm.2.5
 pm/Math/GSL/ODEIV.pm.2.6
+pm/Math/GSL/ODEIV.pm.2.7
 pm/Math/GSL/Permutation.pm.1.15
 pm/Math/GSL/Permutation.pm.1.16
 pm/Math/GSL/Permutation.pm.2.0
@@ -434,6 +468,7 @@ pm/Math/GSL/Permutation.pm.2.3
 pm/Math/GSL/Permutation.pm.2.4
 pm/Math/GSL/Permutation.pm.2.5
 pm/Math/GSL/Permutation.pm.2.6
+pm/Math/GSL/Permutation.pm.2.7
 pm/Math/GSL/Poly.pm.1.15
 pm/Math/GSL/Poly.pm.1.16
 pm/Math/GSL/Poly.pm.2.0
@@ -444,6 +479,7 @@ pm/Math/GSL/Poly.pm.2.3
 pm/Math/GSL/Poly.pm.2.4
 pm/Math/GSL/Poly.pm.2.5
 pm/Math/GSL/Poly.pm.2.6
+pm/Math/GSL/Poly.pm.2.7
 pm/Math/GSL/PowInt.pm.1.15
 pm/Math/GSL/PowInt.pm.1.16
 pm/Math/GSL/PowInt.pm.2.0
@@ -454,6 +490,7 @@ pm/Math/GSL/PowInt.pm.2.3
 pm/Math/GSL/PowInt.pm.2.4
 pm/Math/GSL/PowInt.pm.2.5
 pm/Math/GSL/PowInt.pm.2.6
+pm/Math/GSL/PowInt.pm.2.7
 pm/Math/GSL/QRNG.pm.1.15
 pm/Math/GSL/QRNG.pm.1.16
 pm/Math/GSL/QRNG.pm.2.0
@@ -464,6 +501,7 @@ pm/Math/GSL/QRNG.pm.2.3
 pm/Math/GSL/QRNG.pm.2.4
 pm/Math/GSL/QRNG.pm.2.5
 pm/Math/GSL/QRNG.pm.2.6
+pm/Math/GSL/QRNG.pm.2.7
 pm/Math/GSL/Randist.pm.1.15
 pm/Math/GSL/Randist.pm.1.16
 pm/Math/GSL/Randist.pm.2.0
@@ -474,6 +512,7 @@ pm/Math/GSL/Randist.pm.2.3
 pm/Math/GSL/Randist.pm.2.4
 pm/Math/GSL/Randist.pm.2.5
 pm/Math/GSL/Randist.pm.2.6
+pm/Math/GSL/Randist.pm.2.7
 pm/Math/GSL/RNG.pm.1.15
 pm/Math/GSL/RNG.pm.1.16
 pm/Math/GSL/RNG.pm.2.0
@@ -484,6 +523,7 @@ pm/Math/GSL/RNG.pm.2.3
 pm/Math/GSL/RNG.pm.2.4
 pm/Math/GSL/RNG.pm.2.5
 pm/Math/GSL/RNG.pm.2.6
+pm/Math/GSL/RNG.pm.2.7
 pm/Math/GSL/Roots.pm.1.15
 pm/Math/GSL/Roots.pm.1.16
 pm/Math/GSL/Roots.pm.2.0
@@ -494,6 +534,7 @@ pm/Math/GSL/Roots.pm.2.3
 pm/Math/GSL/Roots.pm.2.4
 pm/Math/GSL/Roots.pm.2.5
 pm/Math/GSL/Roots.pm.2.6
+pm/Math/GSL/Roots.pm.2.7
 pm/Math/GSL/Rstat.pm.2.0
 pm/Math/GSL/Rstat.pm.2.1
 pm/Math/GSL/Rstat.pm.2.2
@@ -502,6 +543,7 @@ pm/Math/GSL/Rstat.pm.2.3
 pm/Math/GSL/Rstat.pm.2.4
 pm/Math/GSL/Rstat.pm.2.5
 pm/Math/GSL/Rstat.pm.2.6
+pm/Math/GSL/Rstat.pm.2.7
 pm/Math/GSL/SF.pm.1.15
 pm/Math/GSL/SF.pm.1.16
 pm/Math/GSL/SF.pm.2.0
@@ -512,6 +554,7 @@ pm/Math/GSL/SF.pm.2.3
 pm/Math/GSL/SF.pm.2.4
 pm/Math/GSL/SF.pm.2.5
 pm/Math/GSL/SF.pm.2.6
+pm/Math/GSL/SF.pm.2.7
 pm/Math/GSL/Siman.pm.1.15
 pm/Math/GSL/Siman.pm.1.16
 pm/Math/GSL/Siman.pm.2.0
@@ -522,6 +565,7 @@ pm/Math/GSL/Siman.pm.2.3
 pm/Math/GSL/Siman.pm.2.4
 pm/Math/GSL/Siman.pm.2.5
 pm/Math/GSL/Siman.pm.2.6
+pm/Math/GSL/Siman.pm.2.7
 pm/Math/GSL/Sort.pm.1.15
 pm/Math/GSL/Sort.pm.1.16
 pm/Math/GSL/Sort.pm.2.0
@@ -532,6 +576,7 @@ pm/Math/GSL/Sort.pm.2.3
 pm/Math/GSL/Sort.pm.2.4
 pm/Math/GSL/Sort.pm.2.5
 pm/Math/GSL/Sort.pm.2.6
+pm/Math/GSL/Sort.pm.2.7
 pm/Math/GSL/SparseMatrix.pm.2.0
 pm/Math/GSL/SparseMatrix.pm.2.1
 pm/Math/GSL/SparseMatrix.pm.2.2
@@ -540,6 +585,7 @@ pm/Math/GSL/SparseMatrix.pm.2.3
 pm/Math/GSL/SparseMatrix.pm.2.4
 pm/Math/GSL/SparseMatrix.pm.2.5
 pm/Math/GSL/SparseMatrix.pm.2.6
+pm/Math/GSL/SparseMatrix.pm.2.7
 pm/Math/GSL/Spline.pm.1.15
 pm/Math/GSL/Spline.pm.1.16
 pm/Math/GSL/Spline.pm.2.0
@@ -550,6 +596,7 @@ pm/Math/GSL/Spline.pm.2.3
 pm/Math/GSL/Spline.pm.2.4
 pm/Math/GSL/Spline.pm.2.5
 pm/Math/GSL/Spline.pm.2.6
+pm/Math/GSL/Spline.pm.2.7
 pm/Math/GSL/Statistics.pm.1.15
 pm/Math/GSL/Statistics.pm.1.16
 pm/Math/GSL/Statistics.pm.2.0
@@ -560,6 +607,7 @@ pm/Math/GSL/Statistics.pm.2.3
 pm/Math/GSL/Statistics.pm.2.4
 pm/Math/GSL/Statistics.pm.2.5
 pm/Math/GSL/Statistics.pm.2.6
+pm/Math/GSL/Statistics.pm.2.7
 pm/Math/GSL/Sum.pm.1.15
 pm/Math/GSL/Sum.pm.1.16
 pm/Math/GSL/Sum.pm.2.0
@@ -570,6 +618,7 @@ pm/Math/GSL/Sum.pm.2.3
 pm/Math/GSL/Sum.pm.2.4
 pm/Math/GSL/Sum.pm.2.5
 pm/Math/GSL/Sum.pm.2.6
+pm/Math/GSL/Sum.pm.2.7
 pm/Math/GSL/Sys.pm.1.15
 pm/Math/GSL/Sys.pm.1.16
 pm/Math/GSL/Sys.pm.2.0
@@ -580,6 +629,7 @@ pm/Math/GSL/Sys.pm.2.3
 pm/Math/GSL/Sys.pm.2.4
 pm/Math/GSL/Sys.pm.2.5
 pm/Math/GSL/Sys.pm.2.6
+pm/Math/GSL/Sys.pm.2.7
 pm/Math/GSL/Vector.pm.1.15
 pm/Math/GSL/Vector.pm.1.16
 pm/Math/GSL/Vector.pm.2.0
@@ -590,6 +640,7 @@ pm/Math/GSL/Vector.pm.2.3
 pm/Math/GSL/Vector.pm.2.4
 pm/Math/GSL/Vector.pm.2.5
 pm/Math/GSL/Vector.pm.2.6
+pm/Math/GSL/Vector.pm.2.7
 pm/Math/GSL/VectorComplex.pm.1.15
 pm/Math/GSL/VectorComplex.pm.1.16
 pm/Math/GSL/VectorComplex.pm.2.0
@@ -600,6 +651,7 @@ pm/Math/GSL/VectorComplex.pm.2.3
 pm/Math/GSL/VectorComplex.pm.2.4
 pm/Math/GSL/VectorComplex.pm.2.5
 pm/Math/GSL/VectorComplex.pm.2.6
+pm/Math/GSL/VectorComplex.pm.2.7
 pm/Math/GSL/Version.pm.1.15
 pm/Math/GSL/Version.pm.1.16
 pm/Math/GSL/Version.pm.2.0
@@ -610,6 +662,7 @@ pm/Math/GSL/Version.pm.2.3
 pm/Math/GSL/Version.pm.2.4
 pm/Math/GSL/Version.pm.2.5
 pm/Math/GSL/Version.pm.2.6
+pm/Math/GSL/Version.pm.2.7
 pm/Math/GSL/Wavelet.pm.1.15
 pm/Math/GSL/Wavelet.pm.1.16
 pm/Math/GSL/Wavelet.pm.2.0
@@ -620,6 +673,7 @@ pm/Math/GSL/Wavelet.pm.2.3
 pm/Math/GSL/Wavelet.pm.2.4
 pm/Math/GSL/Wavelet.pm.2.5
 pm/Math/GSL/Wavelet.pm.2.6
+pm/Math/GSL/Wavelet.pm.2.7
 pm/Math/GSL/Wavelet2D.pm.1.15
 pm/Math/GSL/Wavelet2D.pm.1.16
 pm/Math/GSL/Wavelet2D.pm.2.0
@@ -630,6 +684,7 @@ pm/Math/GSL/Wavelet2D.pm.2.3
 pm/Math/GSL/Wavelet2D.pm.2.4
 pm/Math/GSL/Wavelet2D.pm.2.5
 pm/Math/GSL/Wavelet2D.pm.2.6
+pm/Math/GSL/Wavelet2D.pm.2.7
 pod/BLAS.pod
 pod/BSpline.pod
 pod/CBLAS.pod
@@ -812,6 +867,7 @@ xs/BLAS_wrap.2.3.c
 xs/BLAS_wrap.2.4.c
 xs/BLAS_wrap.2.5.c
 xs/BLAS_wrap.2.6.c
+xs/BLAS_wrap.2.7.c
 xs/BSpline_wrap.1.15.c
 xs/BSpline_wrap.1.16.c
 xs/BSpline_wrap.2.0.c
@@ -822,6 +878,7 @@ xs/BSpline_wrap.2.3.c
 xs/BSpline_wrap.2.4.c
 xs/BSpline_wrap.2.5.c
 xs/BSpline_wrap.2.6.c
+xs/BSpline_wrap.2.7.c
 xs/CBLAS_wrap.1.15.c
 xs/CBLAS_wrap.1.16.c
 xs/CBLAS_wrap.2.0.c
@@ -832,6 +889,7 @@ xs/CBLAS_wrap.2.3.c
 xs/CBLAS_wrap.2.4.c
 xs/CBLAS_wrap.2.5.c
 xs/CBLAS_wrap.2.6.c
+xs/CBLAS_wrap.2.7.c
 xs/CDF_wrap.1.15.c
 xs/CDF_wrap.1.16.c
 xs/CDF_wrap.2.0.c
@@ -842,6 +900,7 @@ xs/CDF_wrap.2.3.c
 xs/CDF_wrap.2.4.c
 xs/CDF_wrap.2.5.c
 xs/CDF_wrap.2.6.c
+xs/CDF_wrap.2.7.c
 xs/Chebyshev_wrap.1.15.c
 xs/Chebyshev_wrap.1.16.c
 xs/Chebyshev_wrap.2.0.c
@@ -852,6 +911,7 @@ xs/Chebyshev_wrap.2.3.c
 xs/Chebyshev_wrap.2.4.c
 xs/Chebyshev_wrap.2.5.c
 xs/Chebyshev_wrap.2.6.c
+xs/Chebyshev_wrap.2.7.c
 xs/Combination_wrap.1.15.c
 xs/Combination_wrap.1.16.c
 xs/Combination_wrap.2.0.c
@@ -862,6 +922,7 @@ xs/Combination_wrap.2.3.c
 xs/Combination_wrap.2.4.c
 xs/Combination_wrap.2.5.c
 xs/Combination_wrap.2.6.c
+xs/Combination_wrap.2.7.c
 xs/Complex_wrap.1.15.c
 xs/Complex_wrap.1.16.c
 xs/Complex_wrap.2.0.c
@@ -872,6 +933,7 @@ xs/Complex_wrap.2.3.c
 xs/Complex_wrap.2.4.c
 xs/Complex_wrap.2.5.c
 xs/Complex_wrap.2.6.c
+xs/Complex_wrap.2.7.c
 xs/Const_wrap.1.15.c
 xs/Const_wrap.1.16.c
 xs/Const_wrap.2.0.c
@@ -882,6 +944,7 @@ xs/Const_wrap.2.3.c
 xs/Const_wrap.2.4.c
 xs/Const_wrap.2.5.c
 xs/Const_wrap.2.6.c
+xs/Const_wrap.2.7.c
 xs/Deriv_wrap.1.15.c
 xs/Deriv_wrap.1.16.c
 xs/Deriv_wrap.2.0.c
@@ -892,6 +955,7 @@ xs/Deriv_wrap.2.3.c
 xs/Deriv_wrap.2.4.c
 xs/Deriv_wrap.2.5.c
 xs/Deriv_wrap.2.6.c
+xs/Deriv_wrap.2.7.c
 xs/DHT_wrap.1.15.c
 xs/DHT_wrap.1.16.c
 xs/DHT_wrap.2.0.c
@@ -902,6 +966,7 @@ xs/DHT_wrap.2.3.c
 xs/DHT_wrap.2.4.c
 xs/DHT_wrap.2.5.c
 xs/DHT_wrap.2.6.c
+xs/DHT_wrap.2.7.c
 xs/Diff_wrap.1.15.c
 xs/Diff_wrap.1.16.c
 xs/Diff_wrap.2.0.c
@@ -912,6 +977,7 @@ xs/Diff_wrap.2.3.c
 xs/Diff_wrap.2.4.c
 xs/Diff_wrap.2.5.c
 xs/Diff_wrap.2.6.c
+xs/Diff_wrap.2.7.c
 xs/Eigen_wrap.1.15.c
 xs/Eigen_wrap.1.16.c
 xs/Eigen_wrap.2.0.c
@@ -922,6 +988,7 @@ xs/Eigen_wrap.2.3.c
 xs/Eigen_wrap.2.4.c
 xs/Eigen_wrap.2.5.c
 xs/Eigen_wrap.2.6.c
+xs/Eigen_wrap.2.7.c
 xs/Errno_wrap.1.15.c
 xs/Errno_wrap.1.16.c
 xs/Errno_wrap.2.0.c
@@ -932,6 +999,7 @@ xs/Errno_wrap.2.3.c
 xs/Errno_wrap.2.4.c
 xs/Errno_wrap.2.5.c
 xs/Errno_wrap.2.6.c
+xs/Errno_wrap.2.7.c
 xs/FFT_wrap.1.15.c
 xs/FFT_wrap.1.16.c
 xs/FFT_wrap.2.0.c
@@ -942,6 +1010,7 @@ xs/FFT_wrap.2.3.c
 xs/FFT_wrap.2.4.c
 xs/FFT_wrap.2.5.c
 xs/FFT_wrap.2.6.c
+xs/FFT_wrap.2.7.c
 xs/Fit_wrap.1.15.c
 xs/Fit_wrap.1.16.c
 xs/Fit_wrap.2.0.c
@@ -952,6 +1021,7 @@ xs/Fit_wrap.2.3.c
 xs/Fit_wrap.2.4.c
 xs/Fit_wrap.2.5.c
 xs/Fit_wrap.2.6.c
+xs/Fit_wrap.2.7.c
 xs/Heapsort_wrap.1.15.c
 xs/Heapsort_wrap.1.16.c
 xs/Heapsort_wrap.2.0.c
@@ -962,6 +1032,7 @@ xs/Heapsort_wrap.2.3.c
 xs/Heapsort_wrap.2.4.c
 xs/Heapsort_wrap.2.5.c
 xs/Heapsort_wrap.2.6.c
+xs/Heapsort_wrap.2.7.c
 xs/Histogram2D_wrap.1.15.c
 xs/Histogram2D_wrap.1.16.c
 xs/Histogram2D_wrap.2.0.c
@@ -972,6 +1043,7 @@ xs/Histogram2D_wrap.2.3.c
 xs/Histogram2D_wrap.2.4.c
 xs/Histogram2D_wrap.2.5.c
 xs/Histogram2D_wrap.2.6.c
+xs/Histogram2D_wrap.2.7.c
 xs/Histogram_wrap.1.15.c
 xs/Histogram_wrap.1.16.c
 xs/Histogram_wrap.2.0.c
@@ -982,6 +1054,7 @@ xs/Histogram_wrap.2.3.c
 xs/Histogram_wrap.2.4.c
 xs/Histogram_wrap.2.5.c
 xs/Histogram_wrap.2.6.c
+xs/Histogram_wrap.2.7.c
 xs/IEEEUtils_wrap.1.15.c
 xs/IEEEUtils_wrap.1.16.c
 xs/IEEEUtils_wrap.2.0.c
@@ -992,6 +1065,7 @@ xs/IEEEUtils_wrap.2.3.c
 xs/IEEEUtils_wrap.2.4.c
 xs/IEEEUtils_wrap.2.5.c
 xs/IEEEUtils_wrap.2.6.c
+xs/IEEEUtils_wrap.2.7.c
 xs/Integration_wrap.1.15.c
 xs/Integration_wrap.1.16.c
 xs/Integration_wrap.2.0.c
@@ -1002,6 +1076,7 @@ xs/Integration_wrap.2.3.c
 xs/Integration_wrap.2.4.c
 xs/Integration_wrap.2.5.c
 xs/Integration_wrap.2.6.c
+xs/Integration_wrap.2.7.c
 xs/Interp_wrap.1.15.c
 xs/Interp_wrap.1.16.c
 xs/Interp_wrap.2.0.c
@@ -1012,6 +1087,7 @@ xs/Interp_wrap.2.3.c
 xs/Interp_wrap.2.4.c
 xs/Interp_wrap.2.5.c
 xs/Interp_wrap.2.6.c
+xs/Interp_wrap.2.7.c
 xs/Linalg_wrap.1.15.c
 xs/Linalg_wrap.1.16.c
 xs/Linalg_wrap.2.0.c
@@ -1022,6 +1098,7 @@ xs/Linalg_wrap.2.3.c
 xs/Linalg_wrap.2.4.c
 xs/Linalg_wrap.2.5.c
 xs/Linalg_wrap.2.6.c
+xs/Linalg_wrap.2.7.c
 xs/Machine_wrap.1.15.c
 xs/Machine_wrap.1.16.c
 xs/Machine_wrap.2.0.c
@@ -1032,6 +1109,7 @@ xs/Machine_wrap.2.3.c
 xs/Machine_wrap.2.4.c
 xs/Machine_wrap.2.5.c
 xs/Machine_wrap.2.6.c
+xs/Machine_wrap.2.7.c
 xs/Matrix_wrap.1.15.c
 xs/Matrix_wrap.1.16.c
 xs/Matrix_wrap.2.0.c
@@ -1042,6 +1120,7 @@ xs/Matrix_wrap.2.3.c
 xs/Matrix_wrap.2.4.c
 xs/Matrix_wrap.2.5.c
 xs/Matrix_wrap.2.6.c
+xs/Matrix_wrap.2.7.c
 xs/MatrixComplex_wrap.1.15.c
 xs/MatrixComplex_wrap.1.16.c
 xs/MatrixComplex_wrap.2.0.c
@@ -1052,6 +1131,7 @@ xs/MatrixComplex_wrap.2.3.c
 xs/MatrixComplex_wrap.2.4.c
 xs/MatrixComplex_wrap.2.5.c
 xs/MatrixComplex_wrap.2.6.c
+xs/MatrixComplex_wrap.2.7.c
 xs/Min_wrap.1.15.c
 xs/Min_wrap.1.16.c
 xs/Min_wrap.2.0.c
@@ -1062,6 +1142,7 @@ xs/Min_wrap.2.3.c
 xs/Min_wrap.2.4.c
 xs/Min_wrap.2.5.c
 xs/Min_wrap.2.6.c
+xs/Min_wrap.2.7.c
 xs/Monte_wrap.1.15.c
 xs/Monte_wrap.1.16.c
 xs/Monte_wrap.2.0.c
@@ -1072,6 +1153,7 @@ xs/Monte_wrap.2.3.c
 xs/Monte_wrap.2.4.c
 xs/Monte_wrap.2.5.c
 xs/Monte_wrap.2.6.c
+xs/Monte_wrap.2.7.c
 xs/Multifit_wrap.2.1.c
 xs/Multifit_wrap.2.2.1.c
 xs/Multifit_wrap.2.2.c
@@ -1079,6 +1161,7 @@ xs/Multifit_wrap.2.3.c
 xs/Multifit_wrap.2.4.c
 xs/Multifit_wrap.2.5.c
 xs/Multifit_wrap.2.6.c
+xs/Multifit_wrap.2.7.c
 xs/Multilarge_wrap.2.1.c
 xs/Multilarge_wrap.2.2.1.c
 xs/Multilarge_wrap.2.2.c
@@ -1086,6 +1169,7 @@ xs/Multilarge_wrap.2.3.c
 xs/Multilarge_wrap.2.4.c
 xs/Multilarge_wrap.2.5.c
 xs/Multilarge_wrap.2.6.c
+xs/Multilarge_wrap.2.7.c
 xs/Multimin_wrap.1.15.c
 xs/Multimin_wrap.1.16.c
 xs/Multimin_wrap.2.0.c
@@ -1096,6 +1180,7 @@ xs/Multimin_wrap.2.3.c
 xs/Multimin_wrap.2.4.c
 xs/Multimin_wrap.2.5.c
 xs/Multimin_wrap.2.6.c
+xs/Multimin_wrap.2.7.c
 xs/Multiroots_wrap.1.15.c
 xs/Multiroots_wrap.1.16.c
 xs/Multiroots_wrap.2.0.c
@@ -1106,6 +1191,7 @@ xs/Multiroots_wrap.2.3.c
 xs/Multiroots_wrap.2.4.c
 xs/Multiroots_wrap.2.5.c
 xs/Multiroots_wrap.2.6.c
+xs/Multiroots_wrap.2.7.c
 xs/Multiset_wrap.1.15.c
 xs/Multiset_wrap.1.16.c
 xs/Multiset_wrap.2.0.c
@@ -1116,6 +1202,7 @@ xs/Multiset_wrap.2.3.c
 xs/Multiset_wrap.2.4.c
 xs/Multiset_wrap.2.5.c
 xs/Multiset_wrap.2.6.c
+xs/Multiset_wrap.2.7.c
 xs/NTuple_wrap.1.15.c
 xs/NTuple_wrap.1.16.c
 xs/NTuple_wrap.2.0.c
@@ -1126,6 +1213,7 @@ xs/NTuple_wrap.2.3.c
 xs/NTuple_wrap.2.4.c
 xs/NTuple_wrap.2.5.c
 xs/NTuple_wrap.2.6.c
+xs/NTuple_wrap.2.7.c
 xs/ODEIV_wrap.1.15.c
 xs/ODEIV_wrap.1.16.c
 xs/ODEIV_wrap.2.0.c
@@ -1136,6 +1224,7 @@ xs/ODEIV_wrap.2.3.c
 xs/ODEIV_wrap.2.4.c
 xs/ODEIV_wrap.2.5.c
 xs/ODEIV_wrap.2.6.c
+xs/ODEIV_wrap.2.7.c
 xs/Permutation_wrap.1.15.c
 xs/Permutation_wrap.1.16.c
 xs/Permutation_wrap.2.0.c
@@ -1146,6 +1235,7 @@ xs/Permutation_wrap.2.3.c
 xs/Permutation_wrap.2.4.c
 xs/Permutation_wrap.2.5.c
 xs/Permutation_wrap.2.6.c
+xs/Permutation_wrap.2.7.c
 xs/Poly_wrap.1.15.c
 xs/Poly_wrap.1.16.c
 xs/Poly_wrap.2.0.c
@@ -1156,6 +1246,7 @@ xs/Poly_wrap.2.3.c
 xs/Poly_wrap.2.4.c
 xs/Poly_wrap.2.5.c
 xs/Poly_wrap.2.6.c
+xs/Poly_wrap.2.7.c
 xs/PowInt_wrap.1.15.c
 xs/PowInt_wrap.1.16.c
 xs/PowInt_wrap.2.0.c
@@ -1166,6 +1257,7 @@ xs/PowInt_wrap.2.3.c
 xs/PowInt_wrap.2.4.c
 xs/PowInt_wrap.2.5.c
 xs/PowInt_wrap.2.6.c
+xs/PowInt_wrap.2.7.c
 xs/QRNG_wrap.1.15.c
 xs/QRNG_wrap.1.16.c
 xs/QRNG_wrap.2.0.c
@@ -1176,6 +1268,7 @@ xs/QRNG_wrap.2.3.c
 xs/QRNG_wrap.2.4.c
 xs/QRNG_wrap.2.5.c
 xs/QRNG_wrap.2.6.c
+xs/QRNG_wrap.2.7.c
 xs/Randist_wrap.1.15.c
 xs/Randist_wrap.1.16.c
 xs/Randist_wrap.2.0.c
@@ -1186,6 +1279,7 @@ xs/Randist_wrap.2.3.c
 xs/Randist_wrap.2.4.c
 xs/Randist_wrap.2.5.c
 xs/Randist_wrap.2.6.c
+xs/Randist_wrap.2.7.c
 xs/RNG_wrap.1.15.c
 xs/RNG_wrap.1.16.c
 xs/RNG_wrap.2.0.c
@@ -1196,6 +1290,7 @@ xs/RNG_wrap.2.3.c
 xs/RNG_wrap.2.4.c
 xs/RNG_wrap.2.5.c
 xs/RNG_wrap.2.6.c
+xs/RNG_wrap.2.7.c
 xs/Roots_wrap.1.15.c
 xs/Roots_wrap.1.16.c
 xs/Roots_wrap.2.0.c
@@ -1206,6 +1301,7 @@ xs/Roots_wrap.2.3.c
 xs/Roots_wrap.2.4.c
 xs/Roots_wrap.2.5.c
 xs/Roots_wrap.2.6.c
+xs/Roots_wrap.2.7.c
 xs/Rstat_wrap.2.0.c
 xs/Rstat_wrap.2.1.c
 xs/Rstat_wrap.2.2.1.c
@@ -1214,6 +1310,7 @@ xs/Rstat_wrap.2.3.c
 xs/Rstat_wrap.2.4.c
 xs/Rstat_wrap.2.5.c
 xs/Rstat_wrap.2.6.c
+xs/Rstat_wrap.2.7.c
 xs/SF_wrap.1.15.c
 xs/SF_wrap.1.16.c
 xs/SF_wrap.2.0.c
@@ -1224,6 +1321,7 @@ xs/SF_wrap.2.3.c
 xs/SF_wrap.2.4.c
 xs/SF_wrap.2.5.c
 xs/SF_wrap.2.6.c
+xs/SF_wrap.2.7.c
 xs/Siman_wrap.1.15.c
 xs/Siman_wrap.1.16.c
 xs/Siman_wrap.2.0.c
@@ -1234,6 +1332,7 @@ xs/Siman_wrap.2.3.c
 xs/Siman_wrap.2.4.c
 xs/Siman_wrap.2.5.c
 xs/Siman_wrap.2.6.c
+xs/Siman_wrap.2.7.c
 xs/Sort_wrap.1.15.c
 xs/Sort_wrap.1.16.c
 xs/Sort_wrap.2.0.c
@@ -1244,6 +1343,7 @@ xs/Sort_wrap.2.3.c
 xs/Sort_wrap.2.4.c
 xs/Sort_wrap.2.5.c
 xs/Sort_wrap.2.6.c
+xs/Sort_wrap.2.7.c
 xs/SparseMatrix_wrap.2.0.c
 xs/SparseMatrix_wrap.2.1.c
 xs/SparseMatrix_wrap.2.2.1.c
@@ -1252,6 +1352,7 @@ xs/SparseMatrix_wrap.2.3.c
 xs/SparseMatrix_wrap.2.4.c
 xs/SparseMatrix_wrap.2.5.c
 xs/SparseMatrix_wrap.2.6.c
+xs/SparseMatrix_wrap.2.7.c
 xs/Spline_wrap.1.15.c
 xs/Spline_wrap.1.16.c
 xs/Spline_wrap.2.0.c
@@ -1262,6 +1363,7 @@ xs/Spline_wrap.2.3.c
 xs/Spline_wrap.2.4.c
 xs/Spline_wrap.2.5.c
 xs/Spline_wrap.2.6.c
+xs/Spline_wrap.2.7.c
 xs/Statistics_wrap.1.15.c
 xs/Statistics_wrap.1.16.c
 xs/Statistics_wrap.2.0.c
@@ -1272,6 +1374,7 @@ xs/Statistics_wrap.2.3.c
 xs/Statistics_wrap.2.4.c
 xs/Statistics_wrap.2.5.c
 xs/Statistics_wrap.2.6.c
+xs/Statistics_wrap.2.7.c
 xs/Sum_wrap.1.15.c
 xs/Sum_wrap.1.16.c
 xs/Sum_wrap.2.0.c
@@ -1282,6 +1385,7 @@ xs/Sum_wrap.2.3.c
 xs/Sum_wrap.2.4.c
 xs/Sum_wrap.2.5.c
 xs/Sum_wrap.2.6.c
+xs/Sum_wrap.2.7.c
 xs/Sys_wrap.1.15.c
 xs/Sys_wrap.1.16.c
 xs/Sys_wrap.2.0.c
@@ -1292,6 +1396,7 @@ xs/Sys_wrap.2.3.c
 xs/Sys_wrap.2.4.c
 xs/Sys_wrap.2.5.c
 xs/Sys_wrap.2.6.c
+xs/Sys_wrap.2.7.c
 xs/Vector_wrap.1.15.c
 xs/Vector_wrap.1.16.c
 xs/Vector_wrap.2.0.c
@@ -1302,6 +1407,7 @@ xs/Vector_wrap.2.3.c
 xs/Vector_wrap.2.4.c
 xs/Vector_wrap.2.5.c
 xs/Vector_wrap.2.6.c
+xs/Vector_wrap.2.7.c
 xs/VectorComplex_wrap.1.15.c
 xs/VectorComplex_wrap.1.16.c
 xs/VectorComplex_wrap.2.0.c
@@ -1312,6 +1418,7 @@ xs/VectorComplex_wrap.2.3.c
 xs/VectorComplex_wrap.2.4.c
 xs/VectorComplex_wrap.2.5.c
 xs/VectorComplex_wrap.2.6.c
+xs/VectorComplex_wrap.2.7.c
 xs/Version_wrap.1.15.c
 xs/Version_wrap.1.16.c
 xs/Version_wrap.2.0.c
@@ -1322,6 +1429,7 @@ xs/Version_wrap.2.3.c
 xs/Version_wrap.2.4.c
 xs/Version_wrap.2.5.c
 xs/Version_wrap.2.6.c
+xs/Version_wrap.2.7.c
 xs/Wavelet2D_wrap.1.15.c
 xs/Wavelet2D_wrap.1.16.c
 xs/Wavelet2D_wrap.2.0.c
@@ -1332,6 +1440,7 @@ xs/Wavelet2D_wrap.2.3.c
 xs/Wavelet2D_wrap.2.4.c
 xs/Wavelet2D_wrap.2.5.c
 xs/Wavelet2D_wrap.2.6.c
+xs/Wavelet2D_wrap.2.7.c
 xs/Wavelet_wrap.1.15.c
 xs/Wavelet_wrap.1.16.c
 xs/Wavelet_wrap.2.0.c
@@ -1342,6 +1451,7 @@ xs/Wavelet_wrap.2.3.c
 xs/Wavelet_wrap.2.4.c
 xs/Wavelet_wrap.2.5.c
 xs/Wavelet_wrap.2.6.c
+xs/Wavelet_wrap.2.7.c
 xt/01-pod.t
 xt/style-trailing-space.t
 META.json

--- a/inc/Ver2Func.pm
+++ b/inc/Ver2Func.pm
@@ -397,7 +397,14 @@ my @ver2func = (
               ^gsl_matrix_uint_scale_columns$
               /
             ]
+    },
+    "2.7" => {
+        new => [
+            qw/
+              /
+        ]
     }
+
 );
 
 my ( %index, @info, @versions );

--- a/swig/SparseMatrix.i
+++ b/swig/SparseMatrix.i
@@ -11,7 +11,7 @@
 
 #if MG_GSL_NUM_VERSION >= 002006
 // ignore gsl_spmatrix_uchar_norm1, gsl_spmatrix_char_norm1, ...
-  %rename("%(regex:/^gsl_spmatrix_.+_norm1$/$ignore/)s") "";
+  %rename("%(regex:/^gsl_spmatrix_u.*_norm1$/$ignore/)s") "";
   %include "gsl/gsl_spmatrix.h"
   %include "gsl/gsl_spmatrix_double.h"
   %include "gsl/gsl_spmatrix_complex_long_double.h"

--- a/swig/SparseMatrix.i
+++ b/swig/SparseMatrix.i
@@ -10,6 +10,8 @@
 %}
 
 #if MG_GSL_NUM_VERSION >= 002006
+// ignore gsl_spmatrix_uchar_norm1, gsl_spmatrix_char_norm1, ...
+  %rename("%(regex:/^gsl_spmatrix_.+_norm1$/$ignore/)s") "";
   %include "gsl/gsl_spmatrix.h"
   %include "gsl/gsl_spmatrix_double.h"
   %include "gsl/gsl_spmatrix_complex_long_double.h"


### PR DESCRIPTION
Builds on #234, which should be merged first.

Updates the `MANIFEST` file to include the newly generated (see PR #230)  `.pm` and `.c` files in the distribution.